### PR TITLE
feat(MediaLive): implement new resource schemas for AWS MediaLive EP-5251 EP-5207 EP-5205

### DIFF
--- a/aws/media_live_channel_configuration_structure.go
+++ b/aws/media_live_channel_configuration_structure.go
@@ -1,4 +1,3 @@
-
 // MediaLive Channel structure helpers.
 //
 // These functions assist in pulling in data from Terraform resource
@@ -134,7 +133,23 @@ func expandAudioCodecSettings(s *schema.Set) *medialive.AudioCodecSettings {
 }
 
 func expandAacCodecSettings(s *schema.Set) *medialive.AacSettings {
-	return &medialive.AacSettings{}
+	if s.Len() > 0 {
+		rawAacSettings := s.List()[0].(map[string]interface{})
+		return &medialive.AacSettings{
+			Bitrate:         aws.Float64(rawAacSettings["bitrate"].(float64)),
+			CodingMode:      aws.String(rawAacSettings["coding_mode"].(string)),
+			InputType:       aws.String(rawAacSettings["input_type"].(string)),
+			Profile:         aws.String(rawAacSettings["profile"].(string)),
+			RateControlMode: aws.String(rawAacSettings["rate_control_mode"].(string)),
+			RawFormat:       aws.String(rawAacSettings["raw_format"].(string)),
+			SampleRate:      aws.Float64(rawAacSettings["sample_rate"].(float64)),
+			Spec:            aws.String(rawAacSettings["spec"].(string)),
+			VbrQuality:      aws.String(rawAacSettings["vbr_quality"].(string)),
+		}
+	} else {
+		log.Printf("[ERROR] MediaLive Channel: AAC Specification can not be found")
+		return &medialive.AacSettings{}
+	}
 }
 
 func expandOutputGroups(outputGroups []interface{}) []*medialive.OutputGroup {
@@ -158,11 +173,32 @@ func expandHlsSettings(hlsSettings []interface{}) []*medialive.HlsSettings {
 }
 
 func expandInputAttachmentSettings(s *schema.Set) *medialive.InputSettings {
-	return &medialive.InputSettings{}
+	if s.Len() > 0 {
+		rawInputSettings := s.List()[0].(map[string]interface{})
+		return &medialive.InputSettings{
+			DeblockFilter:     aws.String(rawInputSettings["deblock_filter"].(string)),
+			DenoiseFilter:     aws.String(rawInputSettings["denoise_filter"].(string)),
+			FilterStrength:    aws.Int64(rawInputSettings["filter_strength"].(int64)),
+			InputFilter:       aws.String(rawInputSettings["input_filter"].(string)),
+			SourceEndBehavior: aws.String(rawInputSettings["source_end_behavior"].(string)),
+		}
+	} else {
+		log.Printf("[ERROR] MediaLive Channel: InputSettings can not be found")
+		return &medialive.InputSettings{}
+	}
 }
 
 func expandTimecodeConfigs(s *schema.Set) *medialive.TimecodeConfig {
-	return nil
+	if s.Len() > 0 {
+		rawTimecodeConfig := s.List()[0].(map[string]interface{})
+		return &medialive.TimecodeConfig{
+			Source:        aws.String(rawTimecodeConfig["source"].(string)),
+			SyncThreshold: aws.Int64(rawTimecodeConfig["sync_threshold"].(int64)),
+		}
+	} else {
+		log.Printf("[ERROR] MediaLive Channel: TimecodeConfig can not be found")
+		return &medialive.TimecodeConfig{}
+	}
 }
 
 func expandVideoDescriptions(videoDescriptions []interface{}) []*medialive.VideoDescription {

--- a/aws/media_live_channel_configuration_structure.go
+++ b/aws/media_live_channel_configuration_structure.go
@@ -1,0 +1,170 @@
+
+// MediaLive Channel structure helpers.
+//
+// These functions assist in pulling in data from Terraform resource
+// configuration for the aws_media_live_channel resource, as there are
+// several sub-fields that require their own data type, and do not necessarily
+// 1-1 translate to resource configuration.
+
+package aws
+
+import (
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/medialive"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func expandInputAttachments(inputAttachments []interface{}) []*medialive.InputAttachment {
+	var result []*medialive.InputAttachment
+	if len(inputAttachments) == 0 {
+		return nil
+	}
+
+	for _, inputAtt := range inputAttachments {
+		r := inputAtt.(map[string]interface{})
+
+		result = append(result, &medialive.InputAttachment{
+			InputAttachmentName: aws.String(r["input_attachment_name"].(string)),
+			InputId:             aws.String(r["input_id"].(string)),
+			InputSettings:       expandInputAttachmentSettings(r["input_settings"].(*schema.Set)),
+		})
+	}
+	return result
+}
+
+func expandInputSpecification(s *schema.Set) *medialive.InputSpecification {
+	if s.Len() > 0 {
+		rawInputSpecification := s.List()[0].(map[string]interface{})
+		return &medialive.InputSpecification{
+			Codec:          aws.String(rawInputSpecification["codec"].(string)),
+			MaximumBitrate: aws.String(rawInputSpecification["maximum_bitrate"].(string)),
+			Resolution:     aws.String(rawInputSpecification["resolution"].(string)),
+		}
+	} else {
+		log.Printf("[WARN] MediaLive Channel: Input Specification can not be found")
+		return &medialive.InputSpecification{}
+	}
+}
+
+func expandDestinations(destinations []interface{}) []*medialive.OutputDestination {
+	var result []*medialive.OutputDestination
+	if len(destinations) == 0 {
+		log.Printf("[WARN] MediaLive Channel: At least one output destination required")
+		return nil
+	}
+
+	for _, destination := range destinations {
+		r := destination.(map[string]interface{})
+
+		result = append(result, &medialive.OutputDestination{
+			Id:       aws.String(r["id"].(string)),
+			Settings: expandOutputDestinationSettings(r["settings"].([]interface{})),
+		})
+	}
+	return result
+}
+
+func expandOutputDestinationSettings(destinationSettings []interface{}) []*medialive.OutputDestinationSettings {
+	var result []*medialive.OutputDestinationSettings
+	if len(destinationSettings) == 0 {
+		log.Printf("[ERROR] MediaLive Channel: One destination setting is required for each redundant encoder")
+		return nil
+	}
+
+	for _, settings := range destinationSettings {
+		r := settings.(map[string]interface{})
+
+		result = append(result, &medialive.OutputDestinationSettings{
+			PasswordParam: aws.String(r["password_param"].(string)),
+			StreamName:    aws.String(r["stream_name"].(string)),
+			Url:           aws.String(r["url"].(string)),
+			Username:      aws.String(r["username"].(string)),
+		})
+	}
+	return result
+}
+
+func expandEncoderSettings(s *schema.Set) *medialive.EncoderSettings {
+	if s.Len() > 0 {
+		rawEncoderSettings := s.List()[0].(map[string]interface{})
+		return &medialive.EncoderSettings{
+			AudioDescriptions: expandAudioDescriptions(rawEncoderSettings["audio_descriptions"].([]interface{})),
+			OutputGroups:      expandOutputGroups(rawEncoderSettings["output_groups"].([]interface{})),
+			TimecodeConfig:    expandTimecodeConfigs(rawEncoderSettings["timecode_config"].(*schema.Set)),
+			VideoDescriptions: expandVideoDescriptions(rawEncoderSettings["video_descriptions"].([]interface{})),
+		}
+	} else {
+		log.Printf("[ERROR] MediaLive Channel: Encoder settings required")
+		return &medialive.EncoderSettings{}
+	}
+}
+
+func expandAudioDescriptions(audioDescriptions []interface{}) []*medialive.AudioDescription {
+	var result []*medialive.AudioDescription
+	if len(audioDescriptions) == 0 {
+		log.Printf("[ERROR] MediaLive Channel: At least one audio description is required for each encoder")
+		return nil
+	}
+
+	for _, descs := range audioDescriptions {
+		r := descs.(map[string]interface{})
+
+		result = append(result, &medialive.AudioDescription{
+			AudioSelectorName: aws.String(r["audio_selector_name"].(string)),
+			Name:              aws.String(r["name"].(string)),
+			StreamName:        aws.String(r["stream_name"].(string)),
+			CodecSettings:     expandAudioCodecSettings(r["codec_settings"].(*schema.Set)),
+		})
+	}
+	return result
+}
+
+func expandAudioCodecSettings(s *schema.Set) *medialive.AudioCodecSettings {
+	if s.Len() > 0 {
+		rawCodecSettings := s.List()[0].(map[string]interface{})
+		return &medialive.AudioCodecSettings{
+			AacSettings: expandAacCodecSettings(rawCodecSettings["aac_settings"].(*schema.Set)),
+		}
+	} else {
+		log.Printf("[WARN] MediaLive Channel: Input Specification can not be found")
+		return &medialive.AudioCodecSettings{}
+	}
+}
+
+func expandAacCodecSettings(s *schema.Set) *medialive.AacSettings {
+	return &medialive.AacSettings{}
+}
+
+func expandOutputGroups(outputGroups []interface{}) []*medialive.OutputGroup {
+	return nil
+}
+
+func expandOutputGroupSettings(outputGroupSettings []interface{}) []*medialive.OutputGroupSettings {
+	return nil
+}
+
+func expandHlsGroupSettings(hlsGroupSettings []interface{}) []*medialive.HlsGroupSettings {
+	return nil
+}
+
+func expandOutputSettings(outputSettings []interface{}) []*medialive.OutputSettings {
+	return nil
+}
+
+func expandHlsSettings(hlsSettings []interface{}) []*medialive.HlsSettings {
+	return nil
+}
+
+func expandInputAttachmentSettings(s *schema.Set) *medialive.InputSettings {
+	return &medialive.InputSettings{}
+}
+
+func expandTimecodeConfigs(s *schema.Set) *medialive.TimecodeConfig {
+	return nil
+}
+
+func expandVideoDescriptions(videoDescriptions []interface{}) []*medialive.VideoDescription {
+	return nil
+}

--- a/aws/media_live_channel_structure.go
+++ b/aws/media_live_channel_structure.go
@@ -111,10 +111,11 @@ func expandAudioDescriptions(audioDescriptions []interface{}) []*medialive.Audio
 		r := descs.(map[string]interface{})
 
 		result = append(result, &medialive.AudioDescription{
-			AudioSelectorName: aws.String(r["audio_selector_name"].(string)),
-			Name:              aws.String(r["name"].(string)),
-			StreamName:        aws.String(r["stream_name"].(string)),
-			CodecSettings:     expandAudioCodecSettings(r["codec_settings"].(*schema.Set)),
+			AudioSelectorName:   aws.String(r["audio_selector_name"].(string)),
+			Name:                aws.String(r["name"].(string)),
+			CodecSettings:       expandAudioCodecSettings(r["codec_settings"].(*schema.Set)),
+			AudioTypeControl:    aws.String(r["audio_type_control"].(string)),
+			LanguageCodeControl: aws.String(r["language_code_control"].(string)),
 		})
 	}
 	return result
@@ -144,7 +145,6 @@ func expandAacCodecSettings(s *schema.Set) *medialive.AacSettings {
 			RawFormat:       aws.String(rawAacSettings["raw_format"].(string)),
 			SampleRate:      aws.Float64(rawAacSettings["sample_rate"].(float64)),
 			Spec:            aws.String(rawAacSettings["spec"].(string)),
-			VbrQuality:      aws.String(rawAacSettings["vbr_quality"].(string)),
 		}
 	} else {
 		log.Printf("[ERROR] MediaLive Channel: AAC Specification can not be found")
@@ -264,16 +264,12 @@ func expandM3u8settings(s *schema.Set) *medialive.M3u8Settings {
 			NielsenId3Behavior:    aws.String(settings["nielsen_id3_behavior"].(string)),
 			PatInterval:           aws.Int64(int64(settings["pat_interval"].(int))),
 			PcrControl:            aws.String(settings["pcr_control"].(string)),
-			PcrPeriod:             aws.Int64(int64(settings["pcr_period"].(int))),
-			PcrPid:                aws.String(settings["pcr_pid"].(string)),
-			PmtInterval:           aws.Int64(int64(settings["pmt_interval"].(int))),
 			PmtPid:                aws.String(settings["pmt_pid"].(string)),
 			ProgramNum:            aws.Int64(int64(settings["program_num"].(int))),
 			Scte35Behavior:        aws.String(settings["scte_35_behavior"].(string)),
 			Scte35Pid:             aws.String(settings["scte_35_pid"].(string)),
 			TimedMetadataBehavior: aws.String(settings["timed_metadata_behavior"].(string)),
 			TimedMetadataPid:      aws.String(settings["timed_metadata_pid"].(string)),
-			TransportStreamId:     aws.Int64(int64(settings["transport_stream_id"].(int))),
 			VideoPid:              aws.String(settings["video_pid"].(string)),
 		}
 	} else {
@@ -286,12 +282,9 @@ func expandHlsGroupSettings(s *schema.Set) *medialive.HlsGroupSettings {
 	if s.Len() > 0 {
 		settings := s.List()[0].(map[string]interface{})
 		return &medialive.HlsGroupSettings{
-			BaseUrlContent:             aws.String(settings["base_url_content"].(string)),
-			BaseUrlManifest:            aws.String(settings["base_url_manifest"].(string)),
 			CaptionLanguageSetting:     aws.String(settings["caption_language_setting"].(string)),
 			CodecSpecification:         aws.String(settings["codec_specification"].(string)),
 			ClientCache:                aws.String(settings["client_cache"].(string)),
-			EncryptionType:             aws.String(settings["encryption_type"].(string)),
 			HlsCdnSettings:             expandHlsCdnSettings(settings["hls_cdn_settings"].(*schema.Set)),
 			HlsId3SegmentTagging:       aws.String(settings["hls_id3_segment_tagging"].(string)),
 			IndexNSegments:             aws.Int64(int64(settings["index_n_segments"].(int))),
@@ -437,8 +430,30 @@ func expandH264Settings(s *schema.Set) *medialive.H264Settings {
 			AdaptiveQuantization: aws.String(rawSettings["adaptive_quantization"].(string)),
 			AfdSignaling:         aws.String(rawSettings["afd_signaling"].(string)),
 			Bitrate:              aws.Int64(int64(rawSettings["bitrate"].(int))),
-			BufFillPct:           aws.Int64(int64(rawSettings["buf_fill_pct"].(int))),
-			BufSize:              aws.Int64(int64(rawSettings["buf_size"].(int))),
+			ColorMetadata:        aws.String(rawSettings["color_metadata"].(string)),
+			EntropyEncoding:      aws.String(rawSettings["entropy_encoding"].(string)),
+			FlickerAq:            aws.String(rawSettings["flicker_aq"].(string)),
+			ForceFieldPictures:   aws.String(rawSettings["force_field_pictures"].(string)),
+			FramerateControl:     aws.String(rawSettings["framerate_control"].(string)),
+			FramerateDenominator: aws.Int64(int64(rawSettings["framerate_denominator"].(int))),
+			FramerateNumerator:   aws.Int64(int64(rawSettings["framerate_numerator"].(int))),
+			GopBReference:        aws.String(rawSettings["gop_b_reference"].(string)),
+			GopClosedCadence:     aws.Int64(int64(rawSettings["gop_closed_cadence"].(int))),
+			GopNumBFrames:        aws.Int64(int64(rawSettings["gop_num_b_frames"].(int))),
+			GopSize:              aws.Float64(rawSettings["gop_size"].(float64)),
+			GopSizeUnits:         aws.String(rawSettings["gop_size_units"].(string)),
+			Level:                aws.String(rawSettings["level"].(string)),
+			LookAheadRateControl: aws.String(rawSettings["look_ahead_rate_control"].(string)),
+			NumRefFrames:         aws.Int64(int64(rawSettings["num_ref_frames"].(int))),
+			ParControl:           aws.String(rawSettings["par_control"].(string)),
+			QualityLevel:         aws.String(rawSettings["quality_level"].(string)),
+			Profile:              aws.String(rawSettings["profile"].(string)),
+			RateControlMode:      aws.String(rawSettings["rate_control_mode"].(string)),
+			Syntax:               aws.String(rawSettings["syntax"].(string)),
+			SceneChangeDetect:    aws.String(rawSettings["scene_change_detect"].(string)),
+			SpatialAq:            aws.String(rawSettings["spatial_aq"].(string)),
+			TemporalAq:           aws.String(rawSettings["temporal_aq"].(string)),
+			TimecodeInsertion:    aws.String(rawSettings["timecode_insertion"].(string)),
 		}
 	} else {
 		log.Printf("[ERROR] MediaLive Channel: H264Settings can not be found")

--- a/aws/media_live_channel_structure.go
+++ b/aws/media_live_channel_structure.go
@@ -430,6 +430,8 @@ func expandH264Settings(s *schema.Set) *medialive.H264Settings {
 			AdaptiveQuantization: aws.String(rawSettings["adaptive_quantization"].(string)),
 			AfdSignaling:         aws.String(rawSettings["afd_signaling"].(string)),
 			Bitrate:              aws.Int64(int64(rawSettings["bitrate"].(int))),
+			BufFillPct:           aws.Int64(int64(rawSettings["buf_fill_pct"].(int))),
+			BufSize:              aws.Int64(int64(rawSettings["buf_size"].(int))),
 			ColorMetadata:        aws.String(rawSettings["color_metadata"].(string)),
 			EntropyEncoding:      aws.String(rawSettings["entropy_encoding"].(string)),
 			FlickerAq:            aws.String(rawSettings["flicker_aq"].(string)),

--- a/aws/media_live_channel_structure.go
+++ b/aws/media_live_channel_structure.go
@@ -195,9 +195,9 @@ func expandOutputs(outputs []interface{}) []*medialive.Output {
 
 		result = append(result, &medialive.Output{
 			OutputName:            aws.String(r["output_name"].(string)),
-			AudioDescriptionNames: expandAudioDescriptionNames(r["audio_description_names"].([]string)),
+			AudioDescriptionNames: expandStringList(r["audio_description_names"].([]interface{})),
 			OutputSettings:        expandOutputSettings(r["output_settings"].(*schema.Set)),
-			VideoDescriptionName:  aws.String(r["video_description_names"].(string)),
+			VideoDescriptionName:  aws.String(r["video_description_name"].(string)),
 		})
 	}
 	return result
@@ -219,9 +219,10 @@ func expandHlsOutputSettings(s *schema.Set) *medialive.HlsOutputSettings {
 	if s.Len() > 0 {
 		settings := s.List()[0].(map[string]interface{})
 		return &medialive.HlsOutputSettings{
-			HlsSettings:     expandHlsSettings(settings["hls_output_settings"].(*schema.Set)),
-			NameModifier:    aws.String(settings["name_modifier"].(string)),
-			SegmentModifier: aws.String(settings["segment_modifier"].(string)),
+			HlsSettings:       expandHlsSettings(settings["hls_settings"].(*schema.Set)),
+			NameModifier:      aws.String(settings["name_modifier"].(string)),
+			H265PackagingType: aws.String(settings["h_265_packaging_type"].(string)),
+			SegmentModifier:   aws.String(settings["segment_modifier"].(string)),
 		}
 	} else {
 		log.Printf("[ERROR] MediaLive Channel: HlsOutputSettings can not be found")
@@ -245,7 +246,8 @@ func expandStandardHlsSettings(s *schema.Set) *medialive.StandardHlsSettings {
 	if s.Len() > 0 {
 		settings := s.List()[0].(map[string]interface{})
 		return &medialive.StandardHlsSettings{
-			M3u8Settings: expandM3u8settings(settings["m3u8_settings"].(*schema.Set)),
+			AudioRenditionSets: aws.String(settings["audio_rendition_sets"].(string)),
+			M3u8Settings:       expandM3u8settings(settings["m3u8_settings"].(*schema.Set)),
 		}
 	} else {
 		log.Printf("[ERROR] MediaLive Channel: StandardHlsSettings can not be found")
@@ -257,21 +259,21 @@ func expandM3u8settings(s *schema.Set) *medialive.M3u8Settings {
 	if s.Len() > 0 {
 		settings := s.List()[0].(map[string]interface{})
 		return &medialive.M3u8Settings{
-			AudioFramesPerPes:     aws.Int64(settings["audio_frames_per_pes"].(int64)),
+			AudioFramesPerPes:     aws.Int64(int64(settings["audio_frames_per_pes"].(int))),
 			AudioPids:             aws.String(settings["audio_pids"].(string)),
 			NielsenId3Behavior:    aws.String(settings["nielsen_id3_behavior"].(string)),
-			PatInterval:           aws.Int64(settings["pat_interval"].(int64)),
+			PatInterval:           aws.Int64(int64(settings["pat_interval"].(int))),
 			PcrControl:            aws.String(settings["pcr_control"].(string)),
-			PcrPeriod:             aws.Int64(settings["pcr_period"].(int64)),
+			PcrPeriod:             aws.Int64(int64(settings["pcr_period"].(int))),
 			PcrPid:                aws.String(settings["pcr_pid"].(string)),
-			PmtInterval:           aws.Int64(settings["pmt_interval"].(int64)),
+			PmtInterval:           aws.Int64(int64(settings["pmt_interval"].(int))),
 			PmtPid:                aws.String(settings["pmt_pid"].(string)),
-			ProgramNum:            aws.Int64(settings["program_num"].(int64)),
+			ProgramNum:            aws.Int64(int64(settings["program_num"].(int))),
 			Scte35Behavior:        aws.String(settings["scte_35_behavior"].(string)),
 			Scte35Pid:             aws.String(settings["scte_35_pid"].(string)),
 			TimedMetadataBehavior: aws.String(settings["timed_metadata_behavior"].(string)),
 			TimedMetadataPid:      aws.String(settings["timed_metadata_pid"].(string)),
-			TransportStreamId:     aws.Int64(settings["transport_stream_id"].(int64)),
+			TransportStreamId:     aws.Int64(int64(settings["transport_stream_id"].(int))),
 			VideoPid:              aws.String(settings["video_pid"].(string)),
 		}
 	} else {
@@ -284,18 +286,37 @@ func expandHlsGroupSettings(s *schema.Set) *medialive.HlsGroupSettings {
 	if s.Len() > 0 {
 		settings := s.List()[0].(map[string]interface{})
 		return &medialive.HlsGroupSettings{
-			BaseUrlContent:         aws.String(settings["base_url_content"].(string)),
-			CaptionLanguageSetting: aws.String(settings["caption_language_setting"].(string)),
-			CodecSpecification:     aws.String(settings["codec_specification"].(string)),
-			ConstantIv:             aws.String(settings["constant_iv"].(string)),
-			ClientCache:            aws.String(settings["client_cache"].(string)),
-			EncryptionType:         aws.String(settings["encryption_type"].(string)),
-			HlsCdnSettings:         expandHlsCdnSettings(settings["hls_cdn_settings"].(*schema.Set)),
-			HlsId3SegmentTagging:   aws.String(settings["hls_id3_segment_tagging"].(string)),
-			IndexNSegments:         aws.Int64(settings["index_n_segments"].(int64)),
-			InputLossAction:        aws.String(settings["input_loss_action"].(string)),
-			IvInManifest:           aws.String(settings["iv_in_manifest"].(string)),
-			IvSource:               aws.String(settings["iv_source"].(string)),
+			BaseUrlContent:             aws.String(settings["base_url_content"].(string)),
+			BaseUrlManifest:            aws.String(settings["base_url_manifest"].(string)),
+			CaptionLanguageSetting:     aws.String(settings["caption_language_setting"].(string)),
+			CodecSpecification:         aws.String(settings["codec_specification"].(string)),
+			ConstantIv:                 aws.String(settings["constant_iv"].(string)),
+			ClientCache:                aws.String(settings["client_cache"].(string)),
+			EncryptionType:             aws.String(settings["encryption_type"].(string)),
+			HlsCdnSettings:             expandHlsCdnSettings(settings["hls_cdn_settings"].(*schema.Set)),
+			HlsId3SegmentTagging:       aws.String(settings["hls_id3_segment_tagging"].(string)),
+			IndexNSegments:             aws.Int64(int64(settings["index_n_segments"].(int))),
+			InputLossAction:            aws.String(settings["input_loss_action"].(string)),
+			IvInManifest:               aws.String(settings["iv_in_manifest"].(string)),
+			IvSource:                   aws.String(settings["iv_source"].(string)),
+			IFrameOnlyPlaylists:        aws.String(settings["iframe_only_playlists"].(string)),
+			KeepSegments:               aws.Int64(int64(settings["keep_segments"].(int))),
+			ManifestCompression:        aws.String(settings["manifest_compression"].(string)),
+			ManifestDurationFormat:     aws.String(settings["manifest_duration_format"].(string)),
+			Mode:                       aws.String(settings["mode"].(string)),
+			OutputSelection:            aws.String(settings["output_selection"].(string)),
+			ProgramDateTime:            aws.String(settings["program_date_time"].(string)),
+			ProgramDateTimePeriod:      aws.Int64(int64(settings["program_date_time_period"].(int))),
+			RedundantManifest:          aws.String(settings["redundant_manifest"].(string)),
+			SegmentationMode:           aws.String(settings["segmentation_mode"].(string)),
+			SegmentLength:              aws.Int64(int64(settings["segment_length"].(int))),
+			DirectoryStructure:         aws.String(settings["directory_structure"].(string)),
+			SegmentsPerSubdirectory:    aws.Int64(int64(settings["segments_per_subdirectory"].(int))),
+			StreamInfResolution:        aws.String(settings["stream_inf_resolution"].(string)),
+			TimedMetadataId3Frame:      aws.String(settings["timed_metadata_id3_frame"].(string)),
+			TimedMetadataId3Period:     aws.Int64(int64(settings["timed_metadata_id3_period"].(int))),
+			TimestampDeltaMilliseconds: aws.Int64(int64(settings["timestamp_delta_milliseconds"].(int))),
+			TsFileMode:                 aws.String(settings["ts_file_mode"].(string)),
 		}
 	} else {
 		log.Printf("[ERROR] MediaLive Channel: HlsGroupSettings can not be found")
@@ -322,28 +343,15 @@ func expandHlsBasicPutSettings(s *schema.Set) *medialive.HlsBasicPutSettings {
 	if s.Len() > 0 {
 		settings := s.List()[0].(map[string]interface{})
 		return &medialive.HlsBasicPutSettings{
-			ConnectionRetryInterval: aws.Int64(settings["connection_retry_interval"].(int64)),
-			FilecacheDuration:       aws.Int64(settings["filecache_duration"].(int64)),
-			NumRetries:              aws.Int64(settings["num_retries"].(int64)),
-			RestartDelay:            aws.Int64(settings["restart_delay"].(int64)),
+			ConnectionRetryInterval: aws.Int64(int64(settings["connection_retry_interval"].(int))),
+			FilecacheDuration:       aws.Int64(int64(settings["filecache_duration"].(int))),
+			NumRetries:              aws.Int64(int64(settings["num_retries"].(int))),
+			RestartDelay:            aws.Int64(int64(settings["restart_delay"].(int))),
 		}
 	} else {
 		log.Printf("[WARN] MediaLive Channel: HlsBasicPutSettings can not be found")
 		return &medialive.HlsBasicPutSettings{}
 	}
-}
-
-func expandAudioDescriptionNames(audioDescriptionNames []string) []*string {
-	var result []*string
-	if len(audioDescriptionNames) == 0 {
-		log.Printf("[ERROR] MediaLive Channel: No AudioDescriptionNames for Output")
-		return nil
-	}
-
-	for _, v := range audioDescriptionNames {
-		result = append(result, aws.String(v))
-	}
-	return result
 }
 
 func expandInputAttachmentSettings(s *schema.Set) *medialive.InputSettings {
@@ -352,7 +360,7 @@ func expandInputAttachmentSettings(s *schema.Set) *medialive.InputSettings {
 		return &medialive.InputSettings{
 			DeblockFilter:     aws.String(rawInputSettings["deblock_filter"].(string)),
 			DenoiseFilter:     aws.String(rawInputSettings["denoise_filter"].(string)),
-			FilterStrength:    aws.Int64(rawInputSettings["filter_strength"].(int64)),
+			FilterStrength:    aws.Int64(int64(rawInputSettings["filter_strength"].(int))),
 			InputFilter:       aws.String(rawInputSettings["input_filter"].(string)),
 			SourceEndBehavior: aws.String(rawInputSettings["source_end_behavior"].(string)),
 		}
@@ -367,7 +375,7 @@ func expandTimecodeConfigs(s *schema.Set) *medialive.TimecodeConfig {
 		rawTimecodeConfig := s.List()[0].(map[string]interface{})
 		return &medialive.TimecodeConfig{
 			Source:        aws.String(rawTimecodeConfig["source"].(string)),
-			SyncThreshold: aws.Int64(rawTimecodeConfig["sync_threshold"].(int64)),
+			SyncThreshold: aws.Int64(int64(rawTimecodeConfig["sync_threshold"].(int))),
 		}
 	} else {
 		log.Printf("[ERROR] MediaLive Channel: TimecodeConfig can not be found")
@@ -387,12 +395,12 @@ func expandVideoDescriptions(videoDescriptions []interface{}) []*medialive.Video
 
 		result = append(result, &medialive.VideoDescription{
 			CodecSettings:   expandVideoCodecSettings(r["codec_settings"].(*schema.Set)),
-			Height:          aws.Int64(r["height"].(int64)),
+			Height:          aws.Int64(int64(r["height"].(int))),
 			Name:            aws.String(r["name"].(string)),
 			RespondToAfd:    aws.String(r["respond_to_afd"].(string)),
 			ScalingBehavior: aws.String(r["scaling_behavior"].(string)),
-			Sharpness:       aws.Int64(r["sharpness"].(int64)),
-			Width:           aws.Int64(r["width"].(int64)),
+			Sharpness:       aws.Int64(int64(r["sharpness"].(int))),
+			Width:           aws.Int64(int64(r["width"].(int))),
 		})
 	}
 	return result
@@ -416,9 +424,9 @@ func expandH264Settings(s *schema.Set) *medialive.H264Settings {
 		return &medialive.H264Settings{
 			AdaptiveQuantization: aws.String(rawSettings["adaptive_quantization"].(string)),
 			AfdSignaling:         aws.String(rawSettings["afd_signaling"].(string)),
-			Bitrate:              aws.Int64(rawSettings["bitrate"].(int64)),
-			BufFillPct:           aws.Int64(rawSettings["buf_fill_pct"].(int64)),
-			BufSize:              aws.Int64(rawSettings["buf_size"].(int64)),
+			Bitrate:              aws.Int64(int64(rawSettings["bitrate"].(int))),
+			BufFillPct:           aws.Int64(int64(rawSettings["buf_fill_pct"].(int))),
+			BufSize:              aws.Int64(int64(rawSettings["buf_size"].(int))),
 		}
 	} else {
 		log.Printf("[ERROR] MediaLive Channel: H264Settings can not be found")

--- a/aws/media_live_channel_structure.go
+++ b/aws/media_live_channel_structure.go
@@ -290,7 +290,6 @@ func expandHlsGroupSettings(s *schema.Set) *medialive.HlsGroupSettings {
 			BaseUrlManifest:            aws.String(settings["base_url_manifest"].(string)),
 			CaptionLanguageSetting:     aws.String(settings["caption_language_setting"].(string)),
 			CodecSpecification:         aws.String(settings["codec_specification"].(string)),
-			ConstantIv:                 aws.String(settings["constant_iv"].(string)),
 			ClientCache:                aws.String(settings["client_cache"].(string)),
 			EncryptionType:             aws.String(settings["encryption_type"].(string)),
 			HlsCdnSettings:             expandHlsCdnSettings(settings["hls_cdn_settings"].(*schema.Set)),
@@ -310,6 +309,7 @@ func expandHlsGroupSettings(s *schema.Set) *medialive.HlsGroupSettings {
 			RedundantManifest:          aws.String(settings["redundant_manifest"].(string)),
 			SegmentationMode:           aws.String(settings["segmentation_mode"].(string)),
 			SegmentLength:              aws.Int64(int64(settings["segment_length"].(int))),
+			Destination:                expandHlsDestinationRef(settings["destination"].(*schema.Set)),
 			DirectoryStructure:         aws.String(settings["directory_structure"].(string)),
 			SegmentsPerSubdirectory:    aws.Int64(int64(settings["segments_per_subdirectory"].(int))),
 			StreamInfResolution:        aws.String(settings["stream_inf_resolution"].(string)),
@@ -336,6 +336,18 @@ func expandHlsCdnSettings(s *schema.Set) *medialive.HlsCdnSettings {
 	} else {
 		log.Printf("[WARN] MediaLive Channel: HlsCdnSettings can not be found")
 		return &medialive.HlsCdnSettings{}
+	}
+}
+
+func expandHlsDestinationRef(s *schema.Set) *medialive.OutputLocationRef {
+	if s.Len() > 0 {
+		settings := s.List()[0].(map[string]interface{})
+		return &medialive.OutputLocationRef{
+			DestinationRefId: aws.String(settings["destination_ref_id"].(string)),
+		}
+	} else {
+		log.Printf("[WARN] MediaLive Channel: HLS Destination (OutputLocationRef) can not be found")
+		return &medialive.OutputLocationRef{}
 	}
 }
 

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -678,6 +678,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_mq_broker":                                           resourceAwsMqBroker(),
 			"aws_mq_configuration":                                    resourceAwsMqConfiguration(),
 			"aws_media_convert_queue":                                 resourceAwsMediaConvertQueue(),
+			"aws_media_live_input_security_group":                     resourceAwsMediaLiveInputSecurityGroup(),
 			"aws_media_package_channel":                               resourceAwsMediaPackageChannel(),
 			"aws_media_store_container":                               resourceAwsMediaStoreContainer(),
 			"aws_media_store_container_policy":                        resourceAwsMediaStoreContainerPolicy(),

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -680,6 +680,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_media_convert_queue":                                 resourceAwsMediaConvertQueue(),
 			"aws_media_live_input_security_group":                     resourceAwsMediaLiveInputSecurityGroup(),
 			"aws_media_live_input":                                    resourceAwsMediaLiveInput(),
+			"aws_media_live_channel":                                  resourceAwsMediaLiveChannel(),
 			"aws_media_package_channel":                               resourceAwsMediaPackageChannel(),
 			"aws_media_store_container":                               resourceAwsMediaStoreContainer(),
 			"aws_media_store_container_policy":                        resourceAwsMediaStoreContainerPolicy(),

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -679,6 +679,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_mq_configuration":                                    resourceAwsMqConfiguration(),
 			"aws_media_convert_queue":                                 resourceAwsMediaConvertQueue(),
 			"aws_media_live_input_security_group":                     resourceAwsMediaLiveInputSecurityGroup(),
+			"aws_media_live_input":                                    resourceAwsMediaLiveInput(),
 			"aws_media_package_channel":                               resourceAwsMediaPackageChannel(),
 			"aws_media_store_container":                               resourceAwsMediaStoreContainer(),
 			"aws_media_store_container_policy":                        resourceAwsMediaStoreContainerPolicy(),

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -682,6 +682,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_media_live_input":                                    resourceAwsMediaLiveInput(),
 			"aws_media_live_channel":                                  resourceAwsMediaLiveChannel(),
 			"aws_media_package_channel":                               resourceAwsMediaPackageChannel(),
+			"aws_media_package_origin_endpoint":                       resourceAwsMediaPackageOriginEndpoint(),
 			"aws_media_store_container":                               resourceAwsMediaStoreContainer(),
 			"aws_media_store_container_policy":                        resourceAwsMediaStoreContainerPolicy(),
 			"aws_msk_cluster":                                         resourceAwsMskCluster(),

--- a/aws/resource_aws_media_live_channel.go
+++ b/aws/resource_aws_media_live_channel.go
@@ -455,8 +455,6 @@ func resourceAwsMediaLiveChannel() *schema.Resource {
 							},
 						},
 
-						//TODO: Nielsen configuration settings.
-
 						"output_groups": {
 							Type:     schema.TypeList,
 							Required: true,
@@ -489,6 +487,106 @@ func resourceAwsMediaLiveChannel() *schema.Resource {
 															},
 														},
 													},
+												},
+											},
+										},
+									},
+
+									"outputs": {
+										Type:     schema.TypeList,
+										Required: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"audio_description_names": {
+													Type:     schema.TypeList,
+													Optional: true,
+													Elem:     &schema.Schema{Type: schema.TypeString},
+												},
+
+												"caption_description_names": {
+													Type:     schema.TypeList,
+													Optional: true,
+													Elem:     &schema.Schema{Type: schema.TypeString},
+												},
+
+												"output_name": {
+													Type:     schema.TypeString,
+													Optional: true,
+												},
+
+												"output_settings": {
+													Type:     schema.TypeSet,
+													Required: true,
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"hls_output_settings": {
+																Type:     schema.TypeSet,
+																Required: true,
+																Elem: &schema.Resource{
+																	Schema: map[string]*schema.Schema{
+																		"h_265_packaging_type": {
+																			Type:     schema.TypeString,
+																			Optional: true,
+																		},
+
+																		"hls_settings": {
+																			Type:     schema.TypeSet,
+																			Required: true,
+																			Elem: &schema.Resource{
+																				Schema: map[string]*schema.Schema{
+																					"standard_hls_settings": {
+																						Type:     schema.TypeSet,
+																						Required: true,
+																						Elem: &schema.Resource{
+																							Schema: map[string]*schema.Schema{
+																								"m3u8_settings": {
+																									Type:     schema.TypeSet,
+																									Required: true,
+																									Elem: &schema.Resource{
+																										Schema: map[string]*schema.Schema{
+																											"audio_frames_per_pes": {
+																												Type:     schema.TypeInt,
+																												Optional: true,
+																											},
+
+																											"audio_pids": {
+																												Type:     schema.TypeString,
+																												Optional: true,
+																											},
+
+																											"nielsen_id3_behavior": {
+																												Type:     schema.TypeString,
+																												Optional: true,
+																											},
+																										},
+																									},
+																								},
+																							},
+																						},
+																					},
+																				},
+																			},
+																		},
+
+																		"name_modifier": {
+																			Type:     schema.TypeString,
+																			Optional: true,
+																		},
+
+																		"segment_modifier": {
+																			Type:     schema.TypeString,
+																			Optional: true,
+																		},
+																	},
+																},
+															},
+														},
+													},
+												},
+
+												"video_description_name": {
+													Type:     schema.TypeString,
+													Optional: true,
 												},
 											},
 										},
@@ -691,6 +789,66 @@ func resourceAwsMediaLiveChannel() *schema.Resource {
 															},
 
 															"profile": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
+
+															"quality_level": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
+
+															"qvbr_quality_level": {
+																Type:     schema.TypeInt,
+																Optional: true,
+															},
+
+															"rate_control_mode": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
+
+															"scan_type": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
+
+															"scene_change_detect": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
+
+															"slices": {
+																Type:     schema.TypeInt,
+																Optional: true,
+															},
+
+															"softness": {
+																Type:     schema.TypeInt,
+																Optional: true,
+															},
+
+															"spatial_aq": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
+
+															"subgop_length": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
+
+															"syntax": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
+
+															"temporal_aq": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
+
+															"timecode_insertion": {
 																Type:     schema.TypeString,
 																Optional: true,
 															},

--- a/aws/resource_aws_media_live_channel.go
+++ b/aws/resource_aws_media_live_channel.go
@@ -113,41 +113,63 @@ func resourceAwsMediaLiveChannel() *schema.Resource {
 							Required: true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
+									// Advanced audio normalization settings.
+									"audio_normalization_settings": {
+										Type:     schema.TypeSet,
+										Optional: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												// Audio normalization algorithm to use. itu17701 conforms to the CALM Act specification,
+												// itu17702 conforms to the EBU R-128 specification.
+												"algorithm": {
+													Type:     schema.TypeString,
+													Optional: true,
+												},
+
+												// When set to correctAudio the output audio is corrected using the chosen algorithm.
+												// If set to measureOnly, the audio will be measured but not adjusted.
+												"algorithm_control": {
+													Type:     schema.TypeString,
+													Optional: true,
+												},
+
+												// Target LKFS(loudness) to adjust volume to. If no value is entered, a default
+												// value will be used according to the chosen algorithm. The CALM Act (1770-1)
+												// recommends a target of -24 LKFS. The EBU R-128 specification (1770-2) recommends
+												// a target of -23 LKFS.
+												"target_lkfs": {
+													Type:     schema.TypeFloat,
+													Optional: true,
+												},
+											},
+										},
+									},
+
+									// The name of the AudioSelector used as the source for this AudioDescription.
 									"audio_selector_name": {
 										Type:     schema.TypeString,
 										Required: true,
 									},
 
+									// Applies only if audioTypeControl is useConfigured. The values for audioType
+									// are defined in ISO-IEC 13818-1.
 									"audio_type": {
 										Type:     schema.TypeString,
 										Required: true,
 									},
 
+									// Determines how audio type is determined. followInput: If the input contains
+									// an ISO 639 audioType, then that value is passed through to the output. If
+									// the input contains no ISO 639 audioType, the value in Audio Type is included
+									// in the output. useConfigured: The value in Audio Type is included in the
+									// output.Note that this field and audioType are both ignored if inputType is
+									// broadcasterMixedAd.
 									"audio_type_control": {
 										Type:     schema.TypeString,
 										Required: true,
 									},
 
-									"language_code": {
-										Type:     schema.TypeString,
-										Required: true,
-									},
-
-									"language_code_control": {
-										Type:     schema.TypeString,
-										Required: true,
-									},
-
-									"name": {
-										Type:     schema.TypeString,
-										Required: true,
-									},
-
-									"stream_name": {
-										Type:     schema.TypeString,
-										Optional: true,
-									},
-
+									// Audio codec settings
 									"codec_settings": {
 										Type:     schema.TypeSet,
 										Optional: true,
@@ -200,8 +222,41 @@ func resourceAwsMediaLiveChannel() *schema.Resource {
 														},
 													},
 												},
+
+												//TODO:
+												// Ac3 Settings
+												// Eac3 Settings
+												// Mp2 Settings
 											},
 										},
+									},
+
+									// Indicates the language of the audio output track. Only used if languageControlMode
+									// is useConfigured, or there is no ISO 639 language code specified in the input.
+									"language_code": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+
+									// Choosing followInput will cause the ISO 639 language code of the output to
+									// follow the ISO 639 language code of the input. The languageCode will be used
+									// when useConfigured is set, or when followInput is selected but there is no
+									// ISO 639 language code specified by the input.
+									"language_code_control": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+
+									"name": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+
+									//TODO: RemixSettings (settings that control how input audio channels are remixed into the output audio channels)
+
+									"stream_name": {
+										Type:     schema.TypeString,
+										Optional: true,
 									},
 								},
 							},

--- a/aws/resource_aws_media_live_channel.go
+++ b/aws/resource_aws_media_live_channel.go
@@ -990,7 +990,7 @@ func resourceAwsMediaLiveChannel() *schema.Resource {
 																Optional: true,
 															},
 
-															"frame_rate_control": {
+															"framerate_control": {
 																Type:     schema.TypeString,
 																Optional: true,
 															},

--- a/aws/resource_aws_media_live_channel.go
+++ b/aws/resource_aws_media_live_channel.go
@@ -14,8 +14,8 @@ func resourceAwsMediaLiveChannel() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceAwsMediaLiveChannelCreate,
 		Read:   resourceAwsMediaLiveChannelRead,
-		Update: nil,
-		Delete: nil,
+		Update: resourceAwsMediaLiveChannelUpdate,
+		Delete: resourceAwsMediaLiveChannelDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
@@ -33,12 +33,116 @@ func resourceAwsMediaLiveChannel() *schema.Resource {
 
 						"input_attachment_name": {
 							Type:     schema.TypeString,
-							Required: true,
+							Optional: true,
+						},
+
+						"automatic_input_failover_settings": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"input_preference": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+
+									"secondary_input_id": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+								},
+							},
 						},
 
 						"input_id": {
 							Type:     schema.TypeString,
-							Computed: true,
+							Required: true,
+						},
+
+						"input_settings": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"source_end_behavior": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+
+									"input_filter": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+
+									"filter_strength": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+
+									"deblock_filter": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+
+									"denoise_filter": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+
+			"destinations": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+
+						"settings": {
+							Type:     schema.TypeList,
+							Required: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"password_param": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+
+									"stream_name": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+
+									"url": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+
+									"user_name": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+								},
+							},
+						},
+
+						"media_package_settings": {
+							Type:     schema.TypeList,
+							Required: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+
+						"multiplex_settings": {
+							Type:     schema.TypeList,
+							Required: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
 					},
 				},
@@ -113,5 +217,13 @@ func resourceAwsMediaLiveChannelRead(d *schema.ResourceData, meta interface{}) e
 		return fmt.Errorf("error setting tags: %s", err)
 	}
 
+	return nil
+}
+
+func resourceAwsMediaLiveChannelUpdate(d *schema.ResourceData, meta interface{}) error {
+	return resourceAwsMediaLiveChannelRead(d, meta)
+}
+
+func resourceAwsMediaLiveChannelDelete(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }

--- a/aws/resource_aws_media_live_channel.go
+++ b/aws/resource_aws_media_live_channel.go
@@ -261,6 +261,301 @@ func resourceAwsMediaLiveChannel() *schema.Resource {
 								},
 							},
 						},
+
+						"avail_blanking": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"avail_blanking_image": {
+										Type:     schema.TypeSet,
+										Optional: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"password_param": {
+													Type:     schedule.TypeString,
+													Optional: true,
+												},
+
+												"uri": {
+													Type:     schedule.TypeString,
+													Required: true,
+												},
+
+												"username": {
+													Type:     schedule.TypeString,
+													Required: true,
+												},
+											},
+										},
+									},
+
+									"state": {
+										Type:     schedule.TypeString,
+										Optional: true,
+									},
+								},
+							},
+						},
+
+						// TODO: avail_configuration (event-wide configuration settings for ad avail insertion).
+
+						"blackout_slate": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"blackout_slate_image": {
+										Type:     schema.TypeSet,
+										Optional: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"password_param": {
+													Type:     schedule.TypeString,
+													Optional: true,
+												},
+
+												"uri": {
+													Type:     schedule.TypeString,
+													Required: true,
+												},
+
+												"username": {
+													Type:     schedule.TypeString,
+													Required: true,
+												},
+											},
+										},
+									},
+
+									"network_end_blackout": {
+										Type:     schedule.TypeString,
+										Optional: true,
+									},
+
+									"network_end_blackout_image": {
+										Type:     schema.TypeSet,
+										Optional: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"password_param": {
+													Type:     schedule.TypeString,
+													Optional: true,
+												},
+
+												"uri": {
+													Type:     schedule.TypeString,
+													Required: true,
+												},
+
+												"username": {
+													Type:     schedule.TypeString,
+													Required: true,
+												},
+											},
+										},
+									},
+
+									"network_id": {
+										Type:     schedule.TypeString,
+										Optional: true,
+									},
+
+									"state": {
+										Type:     schedule.TypeString,
+										Optional: true,
+									},
+								},
+							},
+						},
+
+						// TODO: CaptionDescriptions
+
+						"global_configuration": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"initial_audio_gain": {
+										Type:     schema.TypeInt,
+										Optional: true,
+									},
+
+									"input_end_action": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+
+									"input_loss_behavior": {
+										Type:     schema.TypeSet,
+										Optional: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"black_frame_msec": {
+													Type:     schedule.TypeInt,
+													Optional: true,
+												},
+
+												"input_loss_image_color": {
+													Type:     schedule.TypeString,
+													Optional: true,
+												},
+
+												"input_loss_image_slate": {
+													Type:     schema.TypeSet,
+													Optional: true,
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"password_param": {
+																Type:     schedule.TypeString,
+																Optional: true,
+															},
+
+															"uri": {
+																Type:     schedule.TypeString,
+																Required: true,
+															},
+
+															"username": {
+																Type:     schedule.TypeString,
+																Required: true,
+															},
+														},
+													},
+												},
+
+												"input_loss_image_type": {
+													Type:     schedule.TypeString,
+													Optional: true,
+												},
+
+												"repeat_frame_msec": {
+													Type:     schedule.TypeInt,
+													Optional: true,
+												},
+											},
+										},
+									},
+
+									"output_locking_mode": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+
+									"output_timing_source": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+
+									"support_low_framerate_inputs": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+								},
+							},
+						},
+
+						//TODO: Nielsen configuration settings.
+
+						"output_groups": {
+							Type:     schema.TypeList,
+							Required: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"name": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+
+									"output_group_settings": {
+										Type:     schema.TypeSet,
+										Optional: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"hls_group_settings": {
+													Type:     schema.TypeSet,
+													Optional: true,
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"base_url_content": {
+																Type:     schema.TypeInt,
+																Optional: true,
+															},
+
+															"caption_language_setting": {
+																Type:     schema.TypeString,
+																Optional: true,
+																Default:  "OMIT",
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+
+						"timecode_config": {
+							Type:     schema.TypeSet,
+							Required: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"source": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+
+									// Threshold in frames beyond which output timecode is resynchronized to the
+									// input timecode. Discrepancies below this threshold are permitted to avoid
+									// unnecessary discontinuities in the output timecode. No timecode sync when
+									// this is not specified.
+									"sync_threshold": {
+										Type:     schedule.TypeInt,
+										Optional: true,
+									},
+								},
+							},
+						},
+
+						"video_descriptions": {
+							Type:     schema.TypeList,
+							Required: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"height": {
+										Type:     schema.TypeInt,
+										Required: true,
+									},
+
+									"name": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+
+									"respond_to_afd": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+
+									"scaling_behavior": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+
+									"sharpness": {
+										Type:     schema.TypeInt,
+										Required: true,
+									},
+
+									"width": {
+										Type:     schema.TypeInt,
+										Required: true,
+									},
+								},
+							},
+						},
 					},
 				},
 			},

--- a/aws/resource_aws_media_live_channel.go
+++ b/aws/resource_aws_media_live_channel.go
@@ -99,21 +99,6 @@ func resourceAwsMediaLiveChannel() *schema.Resource {
 				},
 			},
 
-			// The endpoints where outgoing connections initiate from
-			"egress_endpoints": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						// Public IP of where a channel's output comes from
-						"source_ip": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-					},
-				},
-			},
-
 			// Encoder Settings
 			"encoder_settings": {
 				Type:     schema.TypeSet,
@@ -1280,33 +1265,6 @@ func resourceAwsMediaLiveChannel() *schema.Resource {
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,
-			},
-
-			"pipeline_details": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						// The name of the active input attachment currently being ingested by this pipeline.
-						"active_input_attachment_name": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-
-						// The name of the input switch schedule action that occurred most recently
-						// and that resulted in the switch to the current input attachment for this
-						// pipeline.
-						"active_input_switch_action_name": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-
-						"pipeline_id": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-					},
-				},
 			},
 
 			"pipelines_running_count": {

--- a/aws/resource_aws_media_live_channel.go
+++ b/aws/resource_aws_media_live_channel.go
@@ -25,6 +25,177 @@ func resourceAwsMediaLiveChannel() *schema.Resource {
 				Computed: true,
 			},
 
+			// A standard channel has two encoding pipelines and a single pipeline channel only has one.
+			"channel_class": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "STANDARD",
+			},
+
+			"destinations": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+
+						"settings": {
+							Type:     schema.TypeList,
+							Required: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"password_param": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+
+									"stream_name": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+
+									"url": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+
+									"user_name": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+								},
+							},
+						},
+
+						"media_package_settings": {
+							Type:     schema.TypeList,
+							Required: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+
+						"multiplex_settings": {
+							Type:     schema.TypeList,
+							Required: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+					},
+				},
+			},
+
+			//EgressEndpoints
+			// TODO
+
+			// Encoder Settings
+			"encoder_settings": {
+				Type:     schema.TypeSet,
+				Required: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"audio_descriptions": {
+							Type:     schema.TypeList,
+							Required: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"audio_selector_name": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+
+									"audio_type": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+
+									"audio_type_control": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+
+									"language_code": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+
+									"language_code_control": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+
+									"name": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+
+									"stream_name": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+
+									"codec_settings": {
+										Type:     schema.TypeSet,
+										Optional: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"aac_settings": {
+													Type:     schema.TypeSet,
+													Optional: true,
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"input_type": {
+																Type:     schema.TypeString,
+																Required: true,
+															},
+
+															"bitrate": {
+																Type:     schema.TypeString,
+																Required: true,
+															},
+
+															"coding_mode": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
+
+															"raw_format": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
+
+															"spec": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
+
+															"profile": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
+
+															"rate_control_mode": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
+
+															"sample_rate": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+
 			"input_attachments": {
 				Type:     schema.TypeList,
 				Required: true,
@@ -95,59 +266,30 @@ func resourceAwsMediaLiveChannel() *schema.Resource {
 				},
 			},
 
-			"destinations": {
-				Type:     schema.TypeList,
+			"input_specification": {
+				Type:     schema.TypeSet,
 				Required: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"id": {
+						"codec": {
 							Type:     schema.TypeString,
 							Required: true,
 						},
 
-						"settings": {
-							Type:     schema.TypeList,
+						"maximum_bitrate": {
+							Type:     schema.TypeString,
 							Required: true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"password_param": {
-										Type:     schema.TypeString,
-										Required: true,
-									},
-
-									"stream_name": {
-										Type:     schema.TypeString,
-										Required: true,
-									},
-
-									"url": {
-										Type:     schema.TypeString,
-										Required: true,
-									},
-
-									"user_name": {
-										Type:     schema.TypeString,
-										Required: true,
-									},
-								},
-							},
 						},
 
-						"media_package_settings": {
-							Type:     schema.TypeList,
+						"resolution": {
+							Type:     schema.TypeString,
 							Required: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
-						},
-
-						"multiplex_settings": {
-							Type:     schema.TypeList,
-							Required: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
 					},
 				},
 			},
 
+			// The log level the user wants for their channel.
 			"log_level": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -156,6 +298,19 @@ func resourceAwsMediaLiveChannel() *schema.Resource {
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,
+			},
+
+			///PipelineDetails []*PipelineDetail `locationName:"pipelineDetails" type:"list"`
+			// TODO
+
+			"pipelines_running_count": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"reserved": {
+				Type:     schema.TypeString,
+				Optional: true,
 			},
 
 			"role_arn": {

--- a/aws/resource_aws_media_live_channel.go
+++ b/aws/resource_aws_media_live_channel.go
@@ -198,7 +198,7 @@ func resourceAwsMediaLiveChannel() *schema.Resource {
 															},
 
 															"bitrate": {
-																Type:     schema.TypeString,
+																Type:     schema.TypeFloat,
 																Required: true,
 															},
 
@@ -228,6 +228,11 @@ func resourceAwsMediaLiveChannel() *schema.Resource {
 															},
 
 															"sample_rate": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
+
+															"vbr_quality": {
 																Type:     schema.TypeString,
 																Optional: true,
 															},

--- a/aws/resource_aws_media_live_channel.go
+++ b/aws/resource_aws_media_live_channel.go
@@ -568,7 +568,7 @@ func resourceAwsMediaLiveChannel() *schema.Resource {
 																										Schema: map[string]*schema.Schema{
 																											"audio_frames_per_pes": {
 																												Type:     schema.TypeInt,
-																												Optional: true,
+																												Required: true,
 																											},
 
 																											"audio_pids": {
@@ -577,6 +577,71 @@ func resourceAwsMediaLiveChannel() *schema.Resource {
 																											},
 
 																											"nielsen_id3_behavior": {
+																												Type:     schema.TypeString,
+																												Optional: true,
+																											},
+
+																											"pat_interval": {
+																												Type:     schema.TypeInt,
+																												Optional: true,
+																											},
+
+																											"pcr_control": {
+																												Type:     schema.TypeString,
+																												Optional: true,
+																											},
+
+																											"pcr_period": {
+																												Type:     schema.TypeInt,
+																												Optional: true,
+																											},
+
+																											"pcr_pid": {
+																												Type:     schema.TypeString,
+																												Optional: true,
+																											},
+
+																											"pmt_interval": {
+																												Type:     schema.TypeInt,
+																												Optional: true,
+																											},
+
+																											"pmt_pid": {
+																												Type:     schema.TypeString,
+																												Optional: true,
+																											},
+
+																											"program_num": {
+																												Type:     schema.TypeInt,
+																												Optional: true,
+																											},
+
+																											"scte_35_behavior": {
+																												Type:     schema.TypeString,
+																												Optional: true,
+																											},
+
+																											"scte_35_pid": {
+																												Type:     schema.TypeString,
+																												Optional: true,
+																											},
+
+																											"timed_metadata_behavior": {
+																												Type:     schema.TypeString,
+																												Optional: true,
+																											},
+
+																											"timed_metadata_pid": {
+																												Type:     schema.TypeString,
+																												Optional: true,
+																											},
+
+																											"transport_stream_id": {
+																												Type:     schema.TypeInt,
+																												Optional: true,
+																											},
+
+																											"video_pid": {
 																												Type:     schema.TypeString,
 																												Optional: true,
 																											},
@@ -1196,7 +1261,7 @@ func resourceAwsMediaLiveChannelDelete(d *schema.ResourceData, meta interface{})
 func mediaLiveChannelRefreshFunc(conn *medialive.MediaLive, channelId string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		channel, err := conn.DescribeChannel(&medialive.DescribeChannelInput{
-			ChannelId: aws.String(inputId),
+			ChannelId: aws.String(channelId),
 		})
 
 		if isAWSErr(err, medialive.ErrCodeNotFoundException, "") {
@@ -1204,14 +1269,14 @@ func mediaLiveChannelRefreshFunc(conn *medialive.MediaLive, channelId string) re
 		}
 
 		if err != nil {
-			return nil, "", fmt.Errorf("error reading MediaLive Input(%s): %s", inputId, err)
+			return nil, "", fmt.Errorf("error reading MediaLive Input(%s): %s", channelId, err)
 		}
 
-		if input == nil {
+		if channel == nil {
 			return nil, medialive.ChannelStateDeleted, nil
 		}
 
-		return input, aws.StringValue(channel.State), nil
+		return channel, aws.StringValue(channel.State), nil
 	}
 }
 
@@ -1224,7 +1289,7 @@ func waitForMediaLiveChannelDeletion(conn *medialive.MediaLive, channelId string
 		NotFoundChecks: 1,
 	}
 
-	log.Printf("[DEBUG] Waiting for Media Live Channel (%s) deletion", inputId)
+	log.Printf("[DEBUG] Waiting for Media Live Channel (%s) deletion", channelId)
 	_, err := stateConf.WaitForState()
 
 	if isAWSErr(err, medialive.ErrCodeNotFoundException, "") {

--- a/aws/resource_aws_media_live_channel.go
+++ b/aws/resource_aws_media_live_channel.go
@@ -1,0 +1,117 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/medialive"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
+)
+
+func resourceAwsMediaLiveChannel() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsMediaLiveChannelCreate,
+		Read:   resourceAwsMediaLiveChannelRead,
+		Update: nil,
+		Delete: nil,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"input_attachments": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+
+						"input_attachment_name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+
+						"input_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+
+			"log_level": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"role_arn": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"tags": tagsSchema(),
+		},
+	}
+}
+
+func resourceAwsMediaLiveChannelCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).medialiveconn
+
+	input := &medialive.CreateChannelInput{
+		ChannelClass: aws.String(d.Get("input_type").(string)),
+		Name:         aws.String(d.Get("name").(string)),
+		Reserved:     aws.String(d.Get("reserved").(string)),
+		RoleArn:      aws.String(d.Get("role_arn").(string)),
+	}
+
+	if v := d.Get("tags").(map[string]interface{}); len(v) > 0 {
+		input.Tags = keyvaluetags.New(v).IgnoreAws().MedialiveTags()
+	}
+
+	resp, err := conn.CreateChannel(input)
+	if err != nil {
+		return fmt.Errorf("Error creating MediaLive Channel: %s", err)
+	}
+
+	d.SetId(aws.StringValue(resp.Channel.Id))
+
+	return resourceAwsMediaLiveChannelRead(d, meta)
+}
+
+func resourceAwsMediaLiveChannelRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).medialiveconn
+
+	input := &medialive.DescribeChannelInput{
+		ChannelId: aws.String(d.Id()),
+	}
+
+	resp, err := conn.DescribeChannel(input)
+	if err != nil {
+		if isAWSErr(err, medialive.ErrCodeNotFoundException, "") {
+			log.Printf("[WARN] MediaLive Input %s not found, error code (404)", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("Error describing MediaLive Channel(%s): %s", d.Id(), err)
+	}
+
+	d.Set("arn", aws.StringValue(resp.Arn))
+	d.Set("name", aws.StringValue(resp.Name))
+	d.Set("role_arn", aws.StringValue(resp.RoleArn))
+
+	if err := d.Set("tags", keyvaluetags.MedialiveKeyValueTags(resp.Tags).IgnoreAws().Map()); err != nil {
+		return fmt.Errorf("error setting tags: %s", err)
+	}
+
+	return nil
+}

--- a/aws/resource_aws_media_live_channel.go
+++ b/aws/resource_aws_media_live_channel.go
@@ -379,11 +379,13 @@ func resourceAwsMediaLiveChannel() *schema.Resource {
 									"initial_audio_gain": {
 										Type:     schema.TypeInt,
 										Optional: true,
+										Default:  0,
 									},
 
 									"input_end_action": {
 										Type:     schema.TypeString,
 										Optional: true,
+										Default:  "NONE",
 									},
 
 									"input_loss_behavior": {
@@ -440,16 +442,19 @@ func resourceAwsMediaLiveChannel() *schema.Resource {
 									"output_locking_mode": {
 										Type:     schema.TypeString,
 										Optional: true,
+										Default:  "PIPELINE_LOCKING",
 									},
 
 									"output_timing_source": {
 										Type:     schema.TypeString,
 										Optional: true,
+										Default:  "INPUT_CLOCK",
 									},
 
 									"support_low_framerate_inputs": {
 										Type:     schema.TypeString,
 										Optional: true,
+										Default:  "DISABLED",
 									},
 								},
 							},
@@ -987,6 +992,7 @@ func resourceAwsMediaLiveChannel() *schema.Resource {
 			"log_level": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Default:  "DISABLED",
 			},
 
 			"name": {
@@ -1028,7 +1034,7 @@ func resourceAwsMediaLiveChannel() *schema.Resource {
 
 			"reserved": {
 				Type:     schema.TypeString,
-				Optional: true,
+				Computed: true,
 			},
 
 			"role_arn": {
@@ -1045,9 +1051,8 @@ func resourceAwsMediaLiveChannelCreate(d *schema.ResourceData, meta interface{})
 	conn := meta.(*AWSClient).medialiveconn
 
 	input := &medialive.CreateChannelInput{
-		ChannelClass: aws.String(d.Get("input_type").(string)),
+		ChannelClass: aws.String(d.Get("channel_class").(string)),
 		Name:         aws.String(d.Get("name").(string)),
-		Reserved:     aws.String(d.Get("reserved").(string)),
 		RoleArn:      aws.String(d.Get("role_arn").(string)),
 	}
 

--- a/aws/resource_aws_media_live_channel.go
+++ b/aws/resource_aws_media_live_channel.go
@@ -273,17 +273,17 @@ func resourceAwsMediaLiveChannel() *schema.Resource {
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{
 												"password_param": {
-													Type:     schedule.TypeString,
+													Type:     schema.TypeString,
 													Optional: true,
 												},
 
 												"uri": {
-													Type:     schedule.TypeString,
+													Type:     schema.TypeString,
 													Required: true,
 												},
 
 												"username": {
-													Type:     schedule.TypeString,
+													Type:     schema.TypeString,
 													Required: true,
 												},
 											},
@@ -291,7 +291,7 @@ func resourceAwsMediaLiveChannel() *schema.Resource {
 									},
 
 									"state": {
-										Type:     schedule.TypeString,
+										Type:     schema.TypeString,
 										Optional: true,
 									},
 								},
@@ -311,17 +311,17 @@ func resourceAwsMediaLiveChannel() *schema.Resource {
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{
 												"password_param": {
-													Type:     schedule.TypeString,
+													Type:     schema.TypeString,
 													Optional: true,
 												},
 
 												"uri": {
-													Type:     schedule.TypeString,
+													Type:     schema.TypeString,
 													Required: true,
 												},
 
 												"username": {
-													Type:     schedule.TypeString,
+													Type:     schema.TypeString,
 													Required: true,
 												},
 											},
@@ -329,7 +329,7 @@ func resourceAwsMediaLiveChannel() *schema.Resource {
 									},
 
 									"network_end_blackout": {
-										Type:     schedule.TypeString,
+										Type:     schema.TypeString,
 										Optional: true,
 									},
 
@@ -339,17 +339,17 @@ func resourceAwsMediaLiveChannel() *schema.Resource {
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{
 												"password_param": {
-													Type:     schedule.TypeString,
+													Type:     schema.TypeString,
 													Optional: true,
 												},
 
 												"uri": {
-													Type:     schedule.TypeString,
+													Type:     schema.TypeString,
 													Required: true,
 												},
 
 												"username": {
-													Type:     schedule.TypeString,
+													Type:     schema.TypeString,
 													Required: true,
 												},
 											},
@@ -357,12 +357,12 @@ func resourceAwsMediaLiveChannel() *schema.Resource {
 									},
 
 									"network_id": {
-										Type:     schedule.TypeString,
+										Type:     schema.TypeString,
 										Optional: true,
 									},
 
 									"state": {
-										Type:     schedule.TypeString,
+										Type:     schema.TypeString,
 										Optional: true,
 									},
 								},
@@ -392,12 +392,12 @@ func resourceAwsMediaLiveChannel() *schema.Resource {
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{
 												"black_frame_msec": {
-													Type:     schedule.TypeInt,
+													Type:     schema.TypeInt,
 													Optional: true,
 												},
 
 												"input_loss_image_color": {
-													Type:     schedule.TypeString,
+													Type:     schema.TypeString,
 													Optional: true,
 												},
 
@@ -407,17 +407,17 @@ func resourceAwsMediaLiveChannel() *schema.Resource {
 													Elem: &schema.Resource{
 														Schema: map[string]*schema.Schema{
 															"password_param": {
-																Type:     schedule.TypeString,
+																Type:     schema.TypeString,
 																Optional: true,
 															},
 
 															"uri": {
-																Type:     schedule.TypeString,
+																Type:     schema.TypeString,
 																Required: true,
 															},
 
 															"username": {
-																Type:     schedule.TypeString,
+																Type:     schema.TypeString,
 																Required: true,
 															},
 														},
@@ -425,12 +425,12 @@ func resourceAwsMediaLiveChannel() *schema.Resource {
 												},
 
 												"input_loss_image_type": {
-													Type:     schedule.TypeString,
+													Type:     schema.TypeString,
 													Optional: true,
 												},
 
 												"repeat_frame_msec": {
-													Type:     schedule.TypeInt,
+													Type:     schema.TypeInt,
 													Optional: true,
 												},
 											},
@@ -512,7 +512,7 @@ func resourceAwsMediaLiveChannel() *schema.Resource {
 									// unnecessary discontinuities in the output timecode. No timecode sync when
 									// this is not specified.
 									"sync_threshold": {
-										Type:     schedule.TypeInt,
+										Type:     schema.TypeInt,
 										Optional: true,
 									},
 								},
@@ -527,6 +527,178 @@ func resourceAwsMediaLiveChannel() *schema.Resource {
 									"height": {
 										Type:     schema.TypeInt,
 										Required: true,
+									},
+
+									// Video codec settings.
+									"codec_settings": {
+										Type:     schema.TypeSet,
+										Required: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												// The frequency at which to capture frames for inclusion in the output. May
+												// be specified in either seconds or milliseconds, as specified by captureIntervalUnits.
+												"frame_capture_settings": {
+													Type:     schema.TypeSet,
+													Optional: true,
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"capture_interval": {
+																Type:     schema.TypeInt,
+																Required: true,
+															},
+
+															"capture_interval_units": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
+														},
+													},
+												},
+
+												"h264_settings": {
+													Type:     schema.TypeSet,
+													Optional: true,
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"adaptive_quantization": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
+
+															"afd_signaling": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
+
+															"bitrate": {
+																Type:     schema.TypeInt,
+																Optional: true,
+															},
+
+															"buf_fill_pct": {
+																Type:     schema.TypeInt,
+																Optional: true,
+															},
+
+															"buf_size": {
+																Type:     schema.TypeInt,
+																Optional: true,
+															},
+
+															"color_metadata": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
+
+															"entropy_encoding": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
+
+															"fixed_afd": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
+
+															"flicker_aq": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
+
+															"force_field_pictures": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
+
+															"frame_rate_control": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
+
+															"framerate_denominator": {
+																Type:     schema.TypeInt,
+																Optional: true,
+															},
+
+															"framerate_numerator": {
+																Type:     schema.TypeInt,
+																Optional: true,
+															},
+
+															"gop_b_reference": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
+
+															"gop_closed_cadence": {
+																Type:     schema.TypeInt,
+																Optional: true,
+															},
+
+															"gop_num_b_frames": {
+																Type:     schema.TypeInt,
+																Optional: true,
+															},
+
+															"gop_size": {
+																Type:     schema.TypeFloat,
+																Optional: true,
+															},
+
+															"gop_size_units": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
+
+															"level": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
+
+															"look_ahead_rate_control": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
+
+															"max_bitrate": {
+																Type:     schema.TypeInt,
+																Optional: true,
+															},
+
+															"min_i_interval": {
+																Type:     schema.TypeInt,
+																Optional: true,
+															},
+
+															"num_ref_frames": {
+																Type:     schema.TypeInt,
+																Optional: true,
+															},
+
+															"par_control": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
+
+															"par_denominator": {
+																Type:     schema.TypeInt,
+																Optional: true,
+															},
+
+															"par_numerator": {
+																Type:     schema.TypeInt,
+																Optional: true,
+															},
+
+															"profile": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
+														},
+													},
+												},
+											},
+										},
 									},
 
 									"name": {

--- a/aws/resource_aws_media_live_channel.go
+++ b/aws/resource_aws_media_live_channel.go
@@ -32,6 +32,8 @@ func resourceAwsMediaLiveChannel() *schema.Resource {
 				Default:  "STANDARD",
 			},
 
+			// A list of destinations of the channel. For UDP outputs, there is onedestination
+			// per output. For other types (HLS, for example), there isone destination per packager.
 			"destinations": {
 				Type:     schema.TypeList,
 				Required: true,
@@ -85,8 +87,20 @@ func resourceAwsMediaLiveChannel() *schema.Resource {
 				},
 			},
 
-			//EgressEndpoints
-			// TODO
+			// The endpoints where outgoing connections initiate from
+			"egress_endpoints": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						// Public IP of where a channel's output comes from
+						"source_ip": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
 
 			// Encoder Settings
 			"encoder_settings": {
@@ -300,8 +314,32 @@ func resourceAwsMediaLiveChannel() *schema.Resource {
 				Required: true,
 			},
 
-			///PipelineDetails []*PipelineDetail `locationName:"pipelineDetails" type:"list"`
-			// TODO
+			"pipeline_details": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						// The name of the active input attachment currently being ingested by this pipeline.
+						"active_input_attachment_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+
+						// The name of the input switch schedule action that occurred most recently
+						// and that resulted in the switch to the current input attachment for this
+						// pipeline.
+						"active_input_switch_action_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+
+						"pipeline_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
 
 			"pipelines_running_count": {
 				Type:     schema.TypeString,

--- a/aws/resource_aws_media_live_channel.go
+++ b/aws/resource_aws_media_live_channel.go
@@ -649,6 +649,19 @@ func resourceAwsMediaLiveChannel() *schema.Resource {
 																Optional: true,
 															},
 
+															"destination": {
+																Type:     schema.TypeSet,
+																Required: true,
+																Elem: &schema.Resource{
+																	Schema: map[string]*schema.Schema{
+																		"destination_ref_id": {
+																			Type:     schema.TypeString,
+																			Required: true,
+																		},
+																	},
+																},
+															},
+
 															"directory_structure": {
 																Type:     schema.TypeString,
 																Optional: true,

--- a/aws/resource_aws_media_live_channel.go
+++ b/aws/resource_aws_media_live_channel.go
@@ -228,7 +228,7 @@ func resourceAwsMediaLiveChannel() *schema.Resource {
 															},
 
 															"sample_rate": {
-																Type:     schema.TypeString,
+																Type:     schema.TypeFloat,
 																Optional: true,
 															},
 
@@ -498,7 +498,12 @@ func resourceAwsMediaLiveChannel() *schema.Resource {
 													Elem: &schema.Resource{
 														Schema: map[string]*schema.Schema{
 															"base_url_content": {
-																Type:     schema.TypeInt,
+																Type:     schema.TypeString,
+																Optional: true,
+															},
+
+															"base_url_manifest": {
+																Type:     schema.TypeString,
 																Optional: true,
 															},
 
@@ -506,6 +511,177 @@ func resourceAwsMediaLiveChannel() *schema.Resource {
 																Type:     schema.TypeString,
 																Optional: true,
 																Default:  "OMIT",
+															},
+
+															"codec_specification": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
+
+															"constant_iv": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
+
+															"client_cache": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
+
+															"hls_cdn_settings": {
+																Type:     schema.TypeSet,
+																Required: true,
+																Elem: &schema.Resource{
+																	Schema: map[string]*schema.Schema{
+																		"hls_basic_put_settings": {
+																			Type:     schema.TypeSet,
+																			Required: true,
+																			Elem: &schema.Resource{
+																				Schema: map[string]*schema.Schema{
+																					"connection_retry_interval": {
+																						Type:     schema.TypeInt,
+																						Optional: true,
+																					},
+
+																					"filecache_duration": {
+																						Type:     schema.TypeInt,
+																						Optional: true,
+																					},
+
+																					"num_retries": {
+																						Type:     schema.TypeInt,
+																						Optional: true,
+																					},
+
+																					"restart_delay": {
+																						Type:     schema.TypeInt,
+																						Optional: true,
+																					},
+																				},
+																			},
+																		},
+																	},
+																},
+															},
+
+															"encryption_type": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
+
+															"hls_id3_segment_tagging": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
+
+															"index_n_segments": {
+																Type:     schema.TypeInt,
+																Optional: true,
+															},
+
+															"input_loss_action": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
+
+															"iv_in_manifest": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
+
+															"iv_source": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
+
+															"iframe_only_playlists": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
+
+															"keep_segments": {
+																Type:     schema.TypeInt,
+																Optional: true,
+															},
+
+															"manifest_compression": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
+
+															"manifest_duration_format": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
+
+															"mode": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
+
+															"output_selection": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
+
+															"program_date_time": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
+
+															"program_date_time_period": {
+																Type:     schema.TypeInt,
+																Optional: true,
+															},
+
+															"segmentation_mode": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
+
+															"redundant_manifest": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
+
+															"segment_length": {
+																Type:     schema.TypeInt,
+																Optional: true,
+															},
+
+															"directory_structure": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
+
+															"segments_per_subdirectory": {
+																Type:     schema.TypeInt,
+																Optional: true,
+															},
+
+															"stream_inf_resolution": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
+
+															"timed_metadata_id3_frame": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
+
+															"timed_metadata_id3_period": {
+																Type:     schema.TypeInt,
+																Optional: true,
+															},
+
+															"timestamp_delta_milliseconds": {
+																Type:     schema.TypeInt,
+																Optional: true,
+															},
+
+															"ts_file_mode": {
+																Type:     schema.TypeString,
+																Optional: true,
 															},
 														},
 													},
@@ -521,7 +697,7 @@ func resourceAwsMediaLiveChannel() *schema.Resource {
 											Schema: map[string]*schema.Schema{
 												"audio_description_names": {
 													Type:     schema.TypeList,
-													Optional: true,
+													Required: true,
 													Elem:     &schema.Schema{Type: schema.TypeString},
 												},
 
@@ -561,6 +737,11 @@ func resourceAwsMediaLiveChannel() *schema.Resource {
 																						Required: true,
 																						Elem: &schema.Resource{
 																							Schema: map[string]*schema.Schema{
+																								"audio_rendition_sets": {
+																									Type:     schema.TypeString,
+																									Required: true,
+																								},
+
 																								"m3u8_settings": {
 																									Type:     schema.TypeSet,
 																									Required: true,
@@ -673,7 +854,7 @@ func resourceAwsMediaLiveChannel() *schema.Resource {
 
 												"video_description_name": {
 													Type:     schema.TypeString,
-													Optional: true,
+													Required: true,
 												},
 											},
 										},
@@ -1161,7 +1342,7 @@ func resourceAwsMediaLiveChannelCreate(d *schema.ResourceData, meta interface{})
 		)
 	}
 
-	if v, ok := d.GetOk("encoder_settings"); ok && len(v.([]interface{})) > 0 {
+	if v, ok := d.GetOk("encoder_settings"); ok {
 		input.EncoderSettings = expandEncoderSettings(
 			v.(*schema.Set),
 		)

--- a/aws/resource_aws_media_live_input.go
+++ b/aws/resource_aws_media_live_input.go
@@ -77,6 +77,7 @@ func resourceAwsMediaLiveInput() *schema.Resource {
 			"input_security_groups": {
 				Type:     schema.TypeList,
 				Required: true,
+				ForceNew: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 

--- a/aws/resource_aws_media_live_input.go
+++ b/aws/resource_aws_media_live_input.go
@@ -209,11 +209,6 @@ func resourceAwsMediaLiveInputUpdate(d *schema.ResourceData, meta interface{}) e
 		}
 	}
 
-	//TODO : Check if we need to wait here too
-	// if err := waitForMediaLiveInputOperation(conn, d.Id()); err != nil {
-	// 	return fmt.Errorf("Error waiting for operational MediaLive Input (%s): %s", d.Id(), err)
-	// }
-
 	return resourceAwsMediaLiveInputRead(d, meta)
 }
 

--- a/aws/resource_aws_media_live_input.go
+++ b/aws/resource_aws_media_live_input.go
@@ -274,7 +274,6 @@ func waitForMediaLiveInputDeletion(conn *medialive.MediaLive, inputId string) er
 			medialive.InputStateDetached,
 			medialive.InputStateAttached,
 			medialive.InputStateDeleting,
-			medialive.InputStateDeleted,
 		},
 		Target:         []string{medialive.InputStateDeleted},
 		Refresh:        mediaLiveInputRefreshFunc(conn, inputId),

--- a/aws/resource_aws_media_live_input.go
+++ b/aws/resource_aws_media_live_input.go
@@ -1,0 +1,269 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/medialive"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
+)
+
+func resourceAwsMediaLiveInput() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsMediaLiveInputCreate,
+		Read:   resourceAwsMediaLiveInputRead,
+		Update: resourceAwsMediaLiveInputUpdate,
+		Delete: resourceAwsMediaLiveInputDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"destinations": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"ip": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+
+						"port": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+
+						"url": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+
+						"stream_name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+
+			"input_type": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Required: true,
+			},
+
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"role_arn": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"request_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"input_security_groups": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+
+			"tags": tagsSchema(),
+		},
+	}
+}
+
+func resourceAwsMediaLiveInputCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).medialiveconn
+
+	input := &medialive.CreateInputInput{
+		Type:      aws.String(d.Get("input_type").(string)),
+		Name:      aws.String(d.Get("name").(string)),
+		RequestId: aws.String(d.Get("request_id").(string)),
+		RoleArn:   aws.String(d.Get("role_arn").(string)),
+	}
+
+	if v, ok := d.GetOk("destinations"); ok && len(v.([]interface{})) > 0 {
+		input.Destinations = expandDestinations(
+			v.([]interface{}),
+		)
+	}
+
+	if raw, ok := d.GetOk("input_security_groups"); ok {
+		list := raw.([]interface{})
+		inputSecurityGroups := make([]*string, len(list))
+		for i, groupId := range list {
+			inputSecurityGroups[i] = aws.String(groupId.(string))
+		}
+	}
+
+	if v := d.Get("tags").(map[string]interface{}); len(v) > 0 {
+		input.Tags = keyvaluetags.New(v).IgnoreAws().MedialiveTags()
+	}
+
+	resp, err := conn.CreateInput(input)
+	if err != nil {
+		return fmt.Errorf("Error creating MediaLive Input: %s", err)
+	}
+
+	d.SetId(aws.StringValue(resp.Input.Id))
+
+	return resourceAwsMediaLiveInputRead(d, meta)
+}
+
+func resourceAwsMediaLiveInputRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).medialiveconn
+
+	input := &medialive.DescribeInputInput{
+		InputId: aws.String(d.Id()),
+	}
+
+	resp, err := conn.DescribeInput(input)
+	if err != nil {
+		if isAWSErr(err, medialive.ErrCodeNotFoundException, "") {
+			log.Printf("[WARN] MediaLive Input %s not found, error code (404)", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("Error describing MediaLive Input(%s): %s", d.Id(), err)
+	}
+
+	d.Set("arn", aws.StringValue(resp.Arn))
+
+	if err := d.Set("tags", keyvaluetags.MedialiveKeyValueTags(resp.Tags).IgnoreAws().Map()); err != nil {
+		return fmt.Errorf("error setting tags: %s", err)
+	}
+
+	return nil
+}
+
+func resourceAwsMediaLiveInputUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).medialiveconn
+
+	if d.HasChange("input_type") {
+		input := &medialive.UpdateInputInput{
+			Name: aws.String(d.Get("name").(string)),
+		}
+
+		_, err := conn.UpdateInput(input)
+		if err != nil {
+			if isAWSErr(err, medialive.ErrCodeNotFoundException, "") {
+				log.Printf("[WARN] MediaLive Input %s not found, error code (404)", d.Id())
+				d.SetId("")
+				return nil
+			}
+			return fmt.Errorf("Error updating MediaLive Input(%s): %s", d.Id(), err)
+		}
+	}
+
+	if d.HasChange("tags") {
+		o, n := d.GetChange("tags")
+		if err := keyvaluetags.MedialiveUpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
+			return fmt.Errorf("error updating tags: %s", err)
+		}
+	}
+
+	//TODO : Check if we need to wait here too
+	// if err := waitForMediaLiveInputOperation(conn, d.Id()); err != nil {
+	// 	return fmt.Errorf("Error waiting for operational MediaLive Input (%s): %s", d.Id(), err)
+	// }
+
+	return resourceAwsMediaLiveInputRead(d, meta)
+}
+
+func resourceAwsMediaLiveInputDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).medialiveconn
+	input := &medialive.DeleteInputInput{
+		InputId: aws.String(d.Id()),
+	}
+
+	_, err := conn.DeleteInput(input)
+	if err != nil {
+		if isAWSErr(err, medialive.ErrCodeNotFoundException, "") {
+			return nil
+		}
+		return fmt.Errorf("Error deleting MediaLive Input(%s): %s", d.Id(), err)
+	}
+
+	if err := waitForMediaLiveInputDeletion(conn, d.Id()); err != nil {
+		return fmt.Errorf("Error waiting for deleting MediaLive Input(%s): %s", d.Id(), err)
+	}
+
+	return nil
+}
+
+func mediaLiveInputRefreshFunc(conn *medialive.MediaLive, inputId string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		input, err := conn.DescribeInput(&medialive.DescribeInputInput{
+			InputId: aws.String(inputId),
+		})
+
+		if isAWSErr(err, medialive.ErrCodeNotFoundException, "") {
+			return nil, medialive.InputStateDeleted, nil
+		}
+
+		if err != nil {
+			return nil, "", fmt.Errorf("error reading MediaLive Input(%s): %s", inputId, err)
+		}
+
+		if input == nil {
+			return nil, medialive.InputStateDeleted, nil
+		}
+
+		return input, aws.StringValue(input.State), nil
+	}
+}
+
+func waitForMediaLiveInputDeletion(conn *medialive.MediaLive, inputId string) error {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{
+			medialive.InputStateDetached,
+			medialive.InputStateAttached,
+			medialive.InputStateDeleting,
+			medialive.InputStateDeleted,
+		},
+		Target:         []string{medialive.InputStateDeleted},
+		Refresh:        mediaLiveInputRefreshFunc(conn, inputId),
+		Timeout:        30 * time.Minute,
+		NotFoundChecks: 1,
+	}
+
+	log.Printf("[DEBUG] Waiting for Media Live Input (%s) deletion", inputId)
+	_, err := stateConf.WaitForState()
+
+	if isAWSErr(err, medialive.ErrCodeNotFoundException, "") {
+		return nil
+	}
+
+	return err
+}
+
+func expandDestinations(destinations []interface{}) []*medialive.InputDestinationRequest {
+	var result []*medialive.InputDestinationRequest
+	if len(destinations) == 0 {
+		return nil
+	}
+
+	for _, destination := range destinations {
+		r := destination.(map[string]interface{})
+
+		result = append(result, &medialive.InputDestinationRequest{
+			StreamName: aws.String(r["stream_name"].(string)),
+		})
+	}
+	return result
+}

--- a/aws/resource_aws_media_live_input_security_group.go
+++ b/aws/resource_aws_media_live_input_security_group.go
@@ -1,0 +1,247 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/medialive"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
+)
+
+func resourceAwsMediaLiveInputSecurityGroup() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsMediaLiveInputSecurityGroupCreate,
+		Read:   resourceAwsMediaLiveInputSecurityGroupRead,
+		Update: resourceAwsMediaLiveInputSecurityGroupUpdate,
+		Delete: resourceAwsMediaLiveInputSecurityGroupDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"whitelist_rule": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"cidr": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+			"tags": tagsSchema(),
+		},
+	}
+}
+
+func resourceAwsMediaLiveInputSecurityGroupCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).medialiveconn
+
+	input := &medialive.CreateInputSecurityGroupInput{}
+
+	if v, ok := d.GetOk("whitelist_rule"); ok && len(v.([]interface{})) > 0 {
+		input.WhitelistRules = expandWhitelistRules(
+			v.([]interface{}),
+		)
+	}
+
+	if v := d.Get("tags").(map[string]interface{}); len(v) > 0 {
+		input.Tags = keyvaluetags.New(v).IgnoreAws().MedialiveTags()
+	}
+
+	resp, err := conn.CreateInputSecurityGroup(input)
+	if err != nil {
+		return fmt.Errorf("Error creating MediaLive Input Security Group: %s", err)
+	}
+
+	d.SetId(aws.StringValue(resp.SecurityGroup.Id))
+
+	return resourceAwsMediaLiveInputSecurityGroupRead(d, meta)
+}
+
+func resourceAwsMediaLiveInputSecurityGroupRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).medialiveconn
+
+	input := &medialive.DescribeInputSecurityGroupInput{
+		InputSecurityGroupId: aws.String(d.Id()),
+	}
+
+	resp, err := conn.DescribeInputSecurityGroup(input)
+	if err != nil {
+		if isAWSErr(err, medialive.ErrCodeNotFoundException, "") {
+			log.Printf("[WARN] MediaLive Input Security Group %s not found, error code (404)", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("Error describing MediaLive Input Security Group(%s): %s", d.Id(), err)
+	}
+
+	d.Set("arn", aws.StringValue(resp.Arn))
+
+	if err := d.Set("whitelist_rule", flattenWhitelistRules(resp.WhitelistRules)); err != nil {
+		return fmt.Errorf("error setting whitelist_rule: %s", err)
+	}
+
+	if err := d.Set("tags", keyvaluetags.MedialiveKeyValueTags(resp.Tags).IgnoreAws().Map()); err != nil {
+		return fmt.Errorf("error setting tags: %s", err)
+	}
+
+	return nil
+}
+
+func resourceAwsMediaLiveInputSecurityGroupUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).medialiveconn
+
+	if d.HasChange("whitelist_rule") {
+		input := &medialive.UpdateInputSecurityGroupInput{
+			InputSecurityGroupId: aws.String(d.Id()),
+			WhitelistRules: expandWhitelistRules(
+				d.Get("whitelist_rule").([]interface{}),
+			),
+		}
+
+		_, err := conn.UpdateInputSecurityGroup(input)
+		if err != nil {
+			if isAWSErr(err, medialive.ErrCodeNotFoundException, "") {
+				log.Printf("[WARN] MediaLive Input Security Group %s not found, error code (404)", d.Id())
+				d.SetId("")
+				return nil
+			}
+			return fmt.Errorf("Error updating MediaLive Input Security Group(%s): %s", d.Id(), err)
+		}
+	}
+
+	if d.HasChange("tags") {
+		o, n := d.GetChange("tags")
+		if err := keyvaluetags.MedialiveUpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
+			return fmt.Errorf("error updating tags: %s", err)
+		}
+	}
+
+	if err := waitForMediaLiveInputSecurityGroupOperation(conn, d.Id()); err != nil {
+		return fmt.Errorf("Error waiting for operational MediaLive Input Security Group(%s): %s", d.Id(), err)
+	}
+
+	return resourceAwsMediaLiveInputSecurityGroupRead(d, meta)
+}
+
+func resourceAwsMediaLiveInputSecurityGroupDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).medialiveconn
+	input := &medialive.DeleteInputSecurityGroupInput{
+		InputSecurityGroupId: aws.String(d.Id()),
+	}
+
+	_, err := conn.DeleteInputSecurityGroup(input)
+	if err != nil {
+		if isAWSErr(err, medialive.ErrCodeNotFoundException, "") {
+			return nil
+		}
+		return fmt.Errorf("Error deleting MediaLive Input Security Group(%s): %s", d.Id(), err)
+	}
+
+	if err := waitForMediaLiveInputSecurityGroupDeletion(conn, d.Id()); err != nil {
+		return fmt.Errorf("Error waiting for deleting MediaLive Input Security Group(%s): %s", d.Id(), err)
+	}
+
+	return nil
+}
+
+func expandWhitelistRules(whitelistRules []interface{}) []*medialive.InputWhitelistRuleCidr {
+	var result []*medialive.InputWhitelistRuleCidr
+	if len(whitelistRules) == 0 {
+		return nil
+	}
+
+	for _, whitelistRule := range whitelistRules {
+		r := whitelistRule.(map[string]interface{})
+
+		result = append(result, &medialive.InputWhitelistRuleCidr{
+			Cidr: aws.String(r["cidr"].(string)),
+		})
+	}
+	return result
+}
+
+func flattenWhitelistRules(whitelistRules []*medialive.InputWhitelistRule) []map[string]interface{} {
+	result := make([]map[string]interface{}, 0, len(whitelistRules))
+	for _, whitelistRule := range whitelistRules {
+		r := map[string]interface{}{
+			"cidr": aws.StringValue(whitelistRule.Cidr),
+		}
+		result = append(result, r)
+	}
+	return result
+}
+
+func mediaLiveInputSecurityGroupRefreshFunc(conn *medialive.MediaLive, inputSecurityGroupId string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		inputSecurityGroup, err := conn.DescribeInputSecurityGroup(&medialive.DescribeInputSecurityGroupInput{
+			InputSecurityGroupId: aws.String(inputSecurityGroupId),
+		})
+
+		if isAWSErr(err, medialive.ErrCodeNotFoundException, "") {
+			return nil, medialive.InputSecurityGroupStateDeleted, nil
+		}
+
+		if err != nil {
+			return nil, "", fmt.Errorf("error reading MediaLive Input Security Group (%s): %s", inputSecurityGroupId, err)
+		}
+
+		if inputSecurityGroup == nil {
+			return nil, medialive.InputSecurityGroupStateDeleted, nil
+		}
+
+		return inputSecurityGroup, aws.StringValue(inputSecurityGroup.State), nil
+	}
+}
+
+func waitForMediaLiveInputSecurityGroupOperation(conn *medialive.MediaLive, inputSecurityGroupId string) error {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{medialive.InputSecurityGroupStateUpdating},
+		Target: []string{
+			medialive.InputSecurityGroupStateIdle,
+			medialive.InputSecurityGroupStateInUse,
+		},
+		Refresh: mediaLiveInputSecurityGroupRefreshFunc(conn, inputSecurityGroupId),
+		Timeout: 30 * time.Minute,
+	}
+
+	log.Printf("[DEBUG] Waiting for Media Live Input Security Group (%s) Operation", inputSecurityGroupId)
+	_, err := stateConf.WaitForState()
+
+	return err
+}
+
+func waitForMediaLiveInputSecurityGroupDeletion(conn *medialive.MediaLive, inputSecurityGroupId string) error {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{
+			medialive.InputSecurityGroupStateIdle,
+			medialive.InputSecurityGroupStateUpdating,
+			medialive.InputSecurityGroupStateInUse,
+		},
+		Target:         []string{medialive.InputSecurityGroupStateDeleted},
+		Refresh:        mediaLiveInputSecurityGroupRefreshFunc(conn, inputSecurityGroupId),
+		Timeout:        30 * time.Minute,
+		NotFoundChecks: 1,
+	}
+
+	log.Printf("[DEBUG] Waiting for Media Live Input Security Group (%s) deletion", inputSecurityGroupId)
+	_, err := stateConf.WaitForState()
+
+	if isAWSErr(err, medialive.ErrCodeNotFoundException, "") {
+		return nil
+	}
+
+	return err
+}

--- a/aws/resource_aws_media_package_origin_endpoint.go
+++ b/aws/resource_aws_media_package_origin_endpoint.go
@@ -2,15 +2,10 @@ package aws
 
 import (
 	"fmt"
-	"log"
-	"regexp"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/medialive"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/aws/aws-sdk-go/service/mediapackage"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
@@ -24,45 +19,45 @@ func resourceAwsMediaPackageOriginEndpoint() *schema.Resource {
 			State: schema.ImportStatePassthrough,
 		},
 		Schema: map[string]*schema.Schema{
-			"id": {
-				Type:     schema.String,
-				Required: true,
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 
 			"channel_id": {
-				Type:     schema.String,
+				Type:     schema.TypeString,
 				Required: true,
 			},
 
 			"description": {
-				Type:     schema.String,
+				Type:     schema.TypeString,
 				Optional: true,
 			},
 
 			"startover_window_seconds": {
-				Type:     schema.Int,
+				Type:     schema.TypeInt,
 				Optional: true,
 			},
 
 			"time_delay_seconds": {
-				Type:     schema.Int,
+				Type:     schema.TypeInt,
 				Optional: true,
 			},
 
 			"manifest_name": {
-				Type:     schema.String,
+				Type:     schema.TypeString,
 				Optional: true,
 			},
 
 			"whitelist": {
-				Type:     schema.List,
+				Type:     schema.TypeList,
 				Optional: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 
 			"hls_package": {
-				Type:    schema.Set,
-				Optinal: true,
+				Type:     schema.TypeSet,
+				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"segment_duration_seconds": {
@@ -112,8 +107,8 @@ func resourceAwsMediaPackageOriginEndpoint() *schema.Resource {
 						},
 
 						"stream_selection": {
-							Type:    schema.Set,
-							Optinal: true,
+							Type:     schema.TypeSet,
+							Optional: true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"stream_order": {
@@ -126,6 +121,7 @@ func resourceAwsMediaPackageOriginEndpoint() *schema.Resource {
 					},
 				},
 			},
+
 			"origination": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -141,7 +137,6 @@ func resourceAwsMediaPackageOriginEndpointCreate(d *schema.ResourceData, meta in
 
 	input := &mediapackage.CreateOriginEndpointInput{
 		ChannelId:    aws.String(d.Get("channel_id").(string)),
-		Id:           aws.String(d.Get("id").(string)),
 		Description:  aws.String(d.Get("description").(string)),
 		ManifestName: aws.String(d.Get("manifest_name").(string)),
 	}
@@ -155,7 +150,7 @@ func resourceAwsMediaPackageOriginEndpointCreate(d *schema.ResourceData, meta in
 		return fmt.Errorf("Error creating MediaPackage Origin Endpoint: %s", err)
 	}
 
-	d.SetId(aws.StringValue(resp.Channel.Id))
+	d.SetId(aws.StringValue(resp.Id))
 
 	return resourceAwsMediaPackageOriginEndpointRead(d, meta)
 }

--- a/aws/resource_aws_media_package_origin_endpoint.go
+++ b/aws/resource_aws_media_package_origin_endpoint.go
@@ -1,0 +1,173 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/medialive"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
+)
+
+func resourceAwsMediaPackageOriginEndpoint() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsMediaPackageOriginEndpointCreate,
+		Read:   resourceAwsMediaPackageOriginEndpointRead,
+		Update: resourceAwsMediaPackageOriginEndpointUpdate,
+		Delete: resourceAwsMediaPackageOriginEndpointDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:     schema.String,
+				Required: true,
+			},
+
+			"channel_id": {
+				Type:     schema.String,
+				Required: true,
+			},
+
+			"description": {
+				Type:     schema.String,
+				Optional: true,
+			},
+
+			"startover_window_seconds": {
+				Type:     schema.Int,
+				Optional: true,
+			},
+
+			"time_delay_seconds": {
+				Type:     schema.Int,
+				Optional: true,
+			},
+
+			"manifest_name": {
+				Type:     schema.String,
+				Optional: true,
+			},
+
+			"whitelist": {
+				Type:     schema.List,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+
+			"hls_package": {
+				Type:    schema.Set,
+				Optinal: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"segment_duration_seconds": {
+							Type:     schema.TypeInt,
+							Required: true,
+						},
+
+						"playlist_window_seconds": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+
+						"play_list_type": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+
+						"ad_markers": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"ad_triggers": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+
+						"ads_on_delivery_restrictions": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"program_date_time_interval_seconds": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+
+						"include_iframe_only_stream": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+
+						"use_audio_rendition_group": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+
+						"stream_selection": {
+							Type:    schema.Set,
+							Optinal: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"stream_order": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"origination": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"tags": tagsSchema(),
+		},
+	}
+}
+
+func resourceAwsMediaPackageOriginEndpointCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).mediapackageconn
+
+	input := &mediapackage.CreateOriginEndpointInput{
+		ChannelId:    aws.String(d.Get("channel_id").(string)),
+		Id:           aws.String(d.Get("id").(string)),
+		Description:  aws.String(d.Get("description").(string)),
+		ManifestName: aws.String(d.Get("manifest_name").(string)),
+	}
+
+	if v := d.Get("tags").(map[string]interface{}); len(v) > 0 {
+		input.Tags = keyvaluetags.New(v).IgnoreAws().MedialiveTags()
+	}
+
+	resp, err := conn.CreateOriginEndpoint(input)
+	if err != nil {
+		return fmt.Errorf("Error creating MediaPackage Origin Endpoint: %s", err)
+	}
+
+	d.SetId(aws.StringValue(resp.Channel.Id))
+
+	return resourceAwsMediaPackageOriginEndpointRead(d, meta)
+}
+
+func resourceAwsMediaPackageOriginEndpointRead(d *schema.ResourceData, meta interface{}) error {
+	return nil
+}
+
+func resourceAwsMediaPackageOriginEndpointUpdate(d *schema.ResourceData, meta interface{}) error {
+	return resourceAwsMediaPackageOriginEndpointRead(d, meta)
+}
+
+func resourceAwsMediaPackageOriginEndpointDelete(d *schema.ResourceData, meta interface{}) error {
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/bflad/tfproviderlint v0.14.0
 	github.com/client9/misspell v0.3.4
 	github.com/golangci/golangci-lint v1.26.0
+	github.com/google/uuid v1.1.1
 	github.com/hashicorp/aws-sdk-go-base v0.4.0
 	github.com/hashicorp/go-cleanhttp v0.5.1
 	github.com/hashicorp/go-multierror v1.0.0


### PR DESCRIPTION
**NOTE:** If at some point we are ready to submit a PR to mainline `HashiCorp` provider for these new resources, then each new resource implementation must be split into separate granular pull requests for ease of testing and review.

**Description:**

PR implements missing in a mainline provider AWS Elemental MediaLive and MediaPackage resources. Each resource is represented using a Terraform [Schema](https://github.com/hashicorp/terraform-plugin-sdk/tree/master/helper/schema) data type (a type paired one or more properties that describe it’s behaviour) and relies on a Terraform Plugin SDK and AWS Go SDK. Implemented resources are as follows:

1. `aws_media_live_input_security_group`

2. `aws_media_live_input`

3. `aws_media_live_channel` (split into a `structure` which defines flatteners and expanders, and a resource itself)

4. `aws_media_package_origin_endpoint`