### PR TITLE
feat(security/MediaPackage): add support for CDN Authorisation EP-5289

### DIFF
--- a/aws/resource_aws_cloudfront_distribution.go
+++ b/aws/resource_aws_cloudfront_distribution.go
@@ -591,8 +591,9 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 										Required: true,
 									},
 									"value": {
-										Type:     schema.TypeString,
-										Required: true,
+										Type:      schema.TypeString,
+										Required:  true,
+										Sensitive: true,
 									},
 								},
 							},

--- a/aws/resource_aws_media_package_origin_endpoint.go
+++ b/aws/resource_aws_media_package_origin_endpoint.go
@@ -256,6 +256,10 @@ func resourceAwsMediaPackageOriginEndpointUpdate(d *schema.ResourceData, meta in
 		input.HlsPackage = expandHlsPackage(v.(*schema.Set))
 	}
 
+	if v, ok := d.GetOk("authorization"); ok {
+		input.Authorization = expandAuthorization(v.(*schema.Set))
+	}
+
 	_, err := conn.UpdateOriginEndpoint(input)
 	if err != nil {
 		return fmt.Errorf("Error updating MediaPackage Origin Endpoint: %s", err)


### PR DESCRIPTION
Allows to configure a custom packager origin `X-MediaPackage-CDNIdentifier` HTTP header with value stored in the AWS Secrets Manager. Thus MediaPackage origin endpoint will only fulfil playback requests that are authorised between MediaPackage and a Cloudfront distribution. This effectively prevents users from bypassing the CDN in order to directly access content on the origin. Corresponding Terraform configuration block looks as follows:
```
  authorization {
  	cdn_identifier_secret  = secret.arn
	secrets_role_arn       = media_live_iam_role_arn
  }
```