### PR TITLE
fix(channel): add EmbeddedDestinationSettings for captions destination settings EP-9614

### DIFF
--- a/aws/media_live_channel_structure.go
+++ b/aws/media_live_channel_structure.go
@@ -326,7 +326,8 @@ func expandCaptionDestinationSettings(s *schema.Set) *medialive.CaptionDestinati
 	if s.Len() > 0 {
 		settings := s.List()[0].(map[string]interface{})
 		return &medialive.CaptionDestinationSettings{
-			WebvttDestinationSettings: expandWebvttDestinationSettings(settings["webvtt_destination_settings"].(*schema.Set)),
+			WebvttDestinationSettings:   expandWebvttDestinationSettings(settings["webvtt_destination_settings"].(*schema.Set)),
+			EmbeddedDestinationSettings: expandEmbeddedDestinationSettings(settings["embedded_destination_settings"].(*schema.Set)),
 		}
 	} else {
 		return nil
@@ -339,6 +340,14 @@ func expandWebvttDestinationSettings(s *schema.Set) *medialive.WebvttDestination
 		return &medialive.WebvttDestinationSettings{
 			StyleControl: aws.String(settings["style_control"].(string)),
 		}
+	} else {
+		return nil
+	}
+}
+
+func expandEmbeddedDestinationSettings(s *schema.Set) *medialive.EmbeddedDestinationSettings {
+	if s.Len() > 0 {
+		return &medialive.EmbeddedDestinationSettings{}
 	} else {
 		return nil
 	}

--- a/aws/resource_aws_media_live_channel.go
+++ b/aws/resource_aws_media_live_channel.go
@@ -281,7 +281,7 @@ func resourceAwsMediaLiveChannel() *schema.Resource {
 
 									"destination_settings": {
 										Type:     schema.TypeSet,
-										Required: true,
+										Optional: true,
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{
 												"webvtt_destination_settings": {
@@ -296,6 +296,18 @@ func resourceAwsMediaLiveChannel() *schema.Resource {
 															"style_control": {
 																Type:     schema.TypeString,
 																Required: true,
+															},
+														},
+													},
+												},
+												"embedded_destination_settings": {
+													Type:     schema.TypeSet,
+													Optional: true,
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"reserved": {
+																Type:     schema.TypeString,
+																Optional: true,
 															},
 														},
 													},


### PR DESCRIPTION
This change adds parsing for an empty `embedded_destination_settings` block to `EmbeddedDestinationSettings` struct. This struct doesn't have any fields as per the [SDK  documentation](https://docs.aws.amazon.com/sdk-for-go/api/service/medialive/#EmbeddedDestinationSettings) but for some reason Terraform Plugin SDK v1 schema serialiser removes this resource from the final JSON if it doesn't have any fields defined.

I'm not sure if this is a bug, an expected behaviour or , perhaps, I merely misunderstood something in the [schema lib documentation](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema#section-readme), but to avoid wasting time on this, I've added a placeholder field to this schema.