### PR TITLE
fix(MediaPackage): add missing schema behaviours EP-9629

### DIFF
--- a/aws/resource_aws_media_package_origin_endpoint.go
+++ b/aws/resource_aws_media_package_origin_endpoint.go
@@ -47,11 +47,13 @@ func resourceAwsMediaPackageOriginEndpoint() *schema.Resource {
 			"channel_id": {
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 
 			"endpoint_id": {
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 
 			"description": {


### PR DESCRIPTION
Whenever a `channel_id` or an `endpoint_id` changes, provider must recreate these resources. This behaviour was missing initially, probably due to an oversight.