### PR TITLE
feat: Add rmtp output settings for medialive channels EP-11669

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,7 @@ website/node_modules
 log.txt
 markdown-link-check*.txt
 changelog.tmp
-terraform-provider-aws
+terraform-provider-aws*
 aws/testdata/service/cloudformation/examplecompany-exampleservice-exampleresource/bin/handler
 vendor/
 # Test exclusions

--- a/aws/media_live_channel_structure.go
+++ b/aws/media_live_channel_structure.go
@@ -189,7 +189,8 @@ func expandOutputGroupSettings(s *schema.Set) *medialive.OutputGroupSettings {
 	if s.Len() > 0 {
 		settings := s.List()[0].(map[string]interface{})
 		return &medialive.OutputGroupSettings{
-			HlsGroupSettings: expandHlsGroupSettings(settings["hls_group_settings"].(*schema.Set)),
+			HlsGroupSettings:  expandHlsGroupSettings(settings["hls_group_settings"].(*schema.Set)),
+			RtmpGroupSettings: expandRtmpGroupSettings(settings["rtmp_group_settings"].(*schema.Set)),
 		}
 	} else {
 		log.Printf("[ERROR] MediaLive Channel: OutputGroupSettings can not be found")
@@ -228,7 +229,8 @@ func expandOutputSettings(s *schema.Set) *medialive.OutputSettings {
 	if s.Len() > 0 {
 		settings := s.List()[0].(map[string]interface{})
 		return &medialive.OutputSettings{
-			HlsOutputSettings: expandHlsOutputSettings(settings["hls_output_settings"].(*schema.Set)),
+			HlsOutputSettings:  expandHlsOutputSettings(settings["hls_output_settings"].(*schema.Set)),
+			RtmpOutputSettings: expandRtmpOutputSettings(settings["rtmp_output_settings"].(*schema.Set)),
 		}
 	} else {
 		log.Printf("[ERROR] MediaLive Channel: OutputSettings can not be found")
@@ -609,5 +611,48 @@ func expandH264Settings(s *schema.Set) *medialive.H264Settings {
 	} else {
 		log.Printf("[ERROR] MediaLive Channel: H264Settings can not be found")
 		return &medialive.H264Settings{}
+	}
+}
+
+func expandRtmpGroupSettings(s *schema.Set) *medialive.RtmpGroupSettings {
+	if s.Len() > 0 {
+		settings := s.List()[0].(map[string]interface{})
+		return &medialive.RtmpGroupSettings{
+			AuthenticationScheme: aws.String(settings["authentication_scheme"].(string)),
+			CacheFullBehavior:    aws.String(settings["cache_full_behavior"].(string)),
+			CacheLength:          aws.Int64(int64(settings["cache_length"].(int))),
+			CaptionData:          aws.String(settings["caption_data"].(string)),
+			InputLossAction:      aws.String(settings["input_loss_action"].(string)),
+			RestartDelay:         aws.Int64(int64(settings["restart_delay"].(int))),
+		}
+	} else {
+		log.Printf("[ERROR] MediaLive Channel: RtmpGroupSettings can not be found")
+		return &medialive.RtmpGroupSettings{}
+	}
+}
+
+func expandRtmpOutputSettings(s *schema.Set) *medialive.RtmpOutputSettings {
+	if s.Len() > 0 {
+		settings := s.List()[0].(map[string]interface{})
+		return &medialive.RtmpOutputSettings{
+			CertificateMode:         aws.String(settings["certificate_mode"].(string)),
+			ConnectionRetryInterval: aws.Int64(int64(settings["connection_retry_interval"].(int))),
+			NumRetries:              aws.Int64(int64(settings["num_retries"].(int))),
+			Destination:             expandRtmpOutputDestination(settings["destination"].(*schema.Set)),
+		}
+	} else {
+		log.Printf("[ERROR] MediaLive Channel: RtmpOutputSettings can not be found")
+		return &medialive.RtmpOutputSettings{}
+	}
+}
+
+func expandRtmpOutputDestination(s *schema.Set) *medialive.OutputLocationRef {
+	if s.Len() > 0 {
+		settings := s.List()[0].(map[string]interface{})
+		return &medialive.OutputLocationRef{
+			DestinationRefId: aws.String(settings["destination_ref_id"].(string)),
+		}
+	} else {
+		return nil
 	}
 }

--- a/aws/resource_aws_media_live_channel.go
+++ b/aws/resource_aws_media_live_channel.go
@@ -779,6 +779,43 @@ func resourceAwsMediaLiveChannel() *schema.Resource {
 														},
 													},
 												},
+												"rtmp_group_settings": {
+													Type:     schema.TypeSet,
+													Optional: true,
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"authentication_scheme": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
+															"cache_length": {
+																Type:     schema.TypeInt,
+																Optional: true,
+															},
+															"restart_delay": {
+																Type:     schema.TypeInt,
+																Optional: true,
+															},
+															"cache_full_behavior": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
+															"caption_data": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
+															"input_loss_action": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
+															// excluding ad_markers as they aren't
+															// defined for the hls group settings either
+															// "ad_markers": {
+															//
+															// },
+														},
+													},
+												},
 											},
 										},
 									},
@@ -960,6 +997,38 @@ func resourceAwsMediaLiveChannel() *schema.Resource {
 																		"segment_modifier": {
 																			Type:     schema.TypeString,
 																			Optional: true,
+																		},
+																	},
+																},
+															},
+															"rtmp_output_settings": {
+																Type:     schema.TypeSet,
+																Optional: true,
+																Elem: &schema.Resource{
+																	Schema: map[string]*schema.Schema{
+																		"connection_retry_interval": {
+																			Type:     schema.TypeInt,
+																			Optional: true,
+																		},
+																		"num_retries": {
+																			Type:     schema.TypeInt,
+																			Optional: true,
+																		},
+																		"certificate_mode": {
+																			Type:     schema.TypeString,
+																			Optional: true,
+																		},
+																		"destination": {
+																			Type:     schema.TypeSet,
+																			Optional: true,
+																			Elem: &schema.Resource{
+																				Schema: map[string]*schema.Schema{
+																					"destination_ref_id": {
+																						Type:     schema.TypeString,
+																						Optional: true,
+																					},
+																				},
+																			},
 																		},
 																	},
 																},

--- a/aws/resource_aws_media_live_channel.go
+++ b/aws/resource_aws_media_live_channel.go
@@ -65,7 +65,7 @@ func resourceAwsMediaLiveChannel() *schema.Resource {
 								Schema: map[string]*schema.Schema{
 									"password_param": {
 										Type:     schema.TypeString,
-										Required: true,
+										Optional: true,
 									},
 
 									"stream_name": {
@@ -80,7 +80,7 @@ func resourceAwsMediaLiveChannel() *schema.Resource {
 
 									"username": {
 										Type:     schema.TypeString,
-										Required: true,
+										Optional: true,
 									},
 								},
 							},


### PR DESCRIPTION
This PR adds the rmtps output settings for media live channels.

# Todos after merge
- [ ] create release v3.37.8
- [ ] cross compile executable and upload binaries to release
- [ ] everyone needs to update the local provider fs mirror
- [ ] terraform agent for jenkins needs to be updated with the new release
- [ ] terraform.lock.hcl files need to be updated